### PR TITLE
ge/24 Hotfix: explicitly import read.table 

### DIFF
--- a/R/getEvents.R
+++ b/R/getEvents.R
@@ -104,7 +104,7 @@ getEvents = function(experimentId,
     httr::warn_for_status(response)
     if (format == "TSV") {
       content = httr::content(response, "text")
-      content = read.table(text = content, header = headerQ, sep = "\t")
+      content = utils::read.table(text = content, header = headerQ, sep = "\t")
     } else {
       content = httr::content(response, "raw")
     }


### PR DESCRIPTION
gets rid of warning in CircleCI

Fixes #24