### PR TITLE
Fix byName for multiple results

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@ root = true
 [*]
 indent_style = space
 tab_width = 2
+end_of_line = lf

--- a/R/getExperiment.R
+++ b/R/getExperiment.R
@@ -8,7 +8,7 @@
 #' @examples
 #' \dontrun{
 #' getExperiment(experimentId)
-#' getExperiment(experimentId, params = list("fields" = "+name"))
+#' getExperiment(byName("my experiment"))
 #' }
 getExperiment = function(experimentId, params = list()) {
   checkDefined(experimentId)

--- a/R/util.R
+++ b/R/util.R
@@ -131,12 +131,11 @@ lookupByName = function(listpath, name, prop = "name") {
     query = sprintf("eq(%s, \"%s\")", prop, name),
     limit = 2 # need >1 so we can detect ambiguous matches
   ))
-  vals = data.frame(t(unlist(vals)), check.names = FALSE)
-  if (nrow(vals) == 0) {
-    stop(sprintf("Resource with the name '%s' does not exist in the experiment.", name))
+  if (!is.data.frame(vals)) {
+    stop(sprintf("Resource with the name '%s' does not exist.", name))
   }
   if (nrow(vals) > 1) {
-    stop(sprintf("More than one resource with the name '%s' exists in the experiment.", name))
+    stop(sprintf("More than one resource with the name '%s' exists.", name))
   }
 
   val = vals$`_id`

--- a/man/getExperiment.Rd
+++ b/man/getExperiment.Rd
@@ -17,6 +17,6 @@ Retrieves an experiment.
 \examples{
 \dontrun{
 getExperiment(experimentId)
-getExperiment(experimentId, params = list("fields" = "+name"))
+getExperiment(byName("my experiment"))
 }
 }

--- a/tests/testthat/test-createLookup.R
+++ b/tests/testthat/test-createLookup.R
@@ -7,7 +7,7 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
           response = httptest::fake_response(
             req$url,
             req$method,
-            content='{"name":"Tiny plate","created":"2017-06-10T01:00:23.638Z","__v":0,"_id":"593b44a7ff5925084dd96ed1","public":false,"uploader":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"permissions":{},"primaryResearcher":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"updated":"2017-06-10T01:00:25.632Z"}',
+            content='[{"name":"Tiny plate","created":"2017-06-10T01:00:23.638Z","__v":0,"_id":"593b44a7ff5925084dd96ed1","public":false,"uploader":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"permissions":{},"primaryResearcher":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"updated":"2017-06-10T01:00:25.632Z"}]',
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -19,8 +19,8 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
             req$method,
             # Fixed GID, not the one passed in
             content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
-            status_code = 200
-            #headers = list(`Content-Type` = "application/json")
+            status_code = 200,
+            headers = list(`Content-Type` = "application/json")
           )
           return(response)
         },
@@ -37,7 +37,6 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
       expect_equal(resp$name, "my gate")
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4")
-
     }
   )
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -29,3 +29,69 @@ test_that("baseDelete requires baseURL to have been set", {
     expect_error(baseDelete(), "setServer")
   }
 })
+
+test_that("lookupByName stops for 0 matches", {
+  with_mock(
+    `httr::request_perform` = function(req, handle, refresh) {
+      expect_equal(req$method, "GET")
+      expect_match(req$url, "https://cellengine.com/api/v1/experiments")
+      response = httptest::fake_response(
+        req$url,
+        req$method,
+        content='[]',
+        status_code = 200,
+        headers = list(`Content-Type` = "application/json")
+      )
+      return(response)
+    },
+    {
+      setServer("https://cellengine.com")
+      expect_error(lookupByName("experiments", byName("My experiment")),
+                   "Resource with the name 'My experiment' does not exist.")
+    }
+  )
+})
+
+test_that("lookupByName stops for >1 match", {
+  with_mock(
+    `httr::request_perform` = function(req, handle, refresh) {
+      expect_equal(req$method, "GET")
+      expect_match(req$url, "https://cellengine.com/api/v1/experiments")
+      response = httptest::fake_response(
+        req$url,
+        req$method,
+        content='[{"name": "My experiment", "_id": "591a3b441d725115208a6fda"}, {"name": "My experiment", "_id": "591a3b441d725115208a6fdb"}]',
+        status_code = 200,
+        headers = list(`Content-Type` = "application/json")
+      )
+      return(response)
+    },
+    {
+      setServer("https://cellengine.com")
+      expect_error(lookupByName("experiments", byName("My experiment")),
+                   "More than one resource with the name 'My experiment' exists.")
+    }
+  )
+})
+
+test_that("lookupByName returns for 1 match", {
+  with_mock(
+    `httr::request_perform` = function(req, handle, refresh) {
+      expect_equal(req$method, "GET")
+      expect_match(req$url, "https://cellengine.com/api/v1/experiments")
+      response = httptest::fake_response(
+        req$url,
+        req$method,
+        content='[{"name": "My experiment", "_id": "591a3b441d725115208a6fda"}]',
+        status_code = 200,
+        headers = list(`Content-Type` = "application/json")
+      )
+      return(response)
+    },
+    {
+      setServer("https://cellengine.com")
+      expect_equal(lookupByName("experiments", byName("My experiment")),
+                   "591a3b441d725115208a6fda")
+    }
+  )
+})


### PR DESCRIPTION
#32 broke this when there were 2 matching resources in the API response. Added tests for all three scenarios, fixed the bug and fixed the mocked HTTP response for `create_lookup`.

Also adjusts the language so that it's not specific to experiment subresources (e.g. works with `getExperiment(byName("name"))`).