### PR TITLE
bug: split-gate y should default to 0.5

### DIFF
--- a/R/createSplitGate.R
+++ b/R/createSplitGate.R
@@ -36,7 +36,7 @@
 #' \dontrun{
 #' createSplitGate(experimentId, "FSC-A", "my gate", 144000, 100000)
 #' }
-createSplitGate = function(experimentId, xChannel, name, x, y,
+createSplitGate = function(experimentId, xChannel, name, x, y=0.5,
                                gid = generateId(), gids = replicate(2, generateId()), labels = NULL,
                                parentPopulationId = NULL, parentPopulation = NULL,
                                tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,

--- a/tests/testthat/test-createSplitGate.R
+++ b/tests/testthat/test-createSplitGate.R
@@ -20,7 +20,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, 0.5, labels = list(c(26215.4,0.95), c(235929.6, 0.95)), createPopulation = FALSE)
+      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, labels = list(c(26215.4,0.95), c(235929.6, 0.95)), createPopulation = FALSE)
       resp = resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
@@ -60,7 +60,7 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     },
     {
       setServer("https://my.server.com")
-      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, 0.5, labels = list(c(26215.4,0.95), c(235929.6, 0.95)),
+      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, labels = list(c(26215.4,0.95), c(235929.6, 0.95)),
                              tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE)
       resp = resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
@@ -121,7 +121,7 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
     },
     {
       setServer("https://my.server.com")
-      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, 0.5, labels = list(c(26215.4,0.95), c(235929.6, 0.95)),
+      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, labels = list(c(26215.4,0.95), c(235929.6, 0.95)),
                              parentPopulation = "singlets", createPopulation = FALSE, tailoredPerFile = FALSE)
       resp = resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")


### PR DESCRIPTION
Set default `y` for `createSplitGate` to 0.5, modified tests

Closes https://github.com/primitybio/cellengine-r-toolkit/issues/38