### PR TITLE
feat(auth): support 2FA and prompt for passwords

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,8 @@
 on:
   push:
     branches:
-      - main
       - master
   pull_request:
-    branches:
-      - main
-      - master
 
 name: R-CMD-check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `downloadFcsFiles` function
 - `downloadAttachment` function
+- The `authenticate` function will now prompt for a password if omitted and
+  running in RStudio or the `getPass` library is installed.
+- The `authenticate` function now supports two-factor authentication.
 
 ### Changed
 - fix for [confusing bulk entity retrieval](https://github.com/primitybio/cellengine-r-toolkit/issues/48)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ LazyData: true
 Depends: R (>= 3.0.0)
 Imports: httr(>= 1.3.0), jsonlite, utils
 RoxygenNote: 7.1.1
-Suggests: httptest(>= 3.2.2), testthat
+Suggests: httptest(>= 3.2.2), testthat, getPass, rstudioapi

--- a/R/authenticate.R
+++ b/R/authenticate.R
@@ -1,24 +1,71 @@
 #' Authenticate
 #'
-#' Authenticates with the server. Call \code{\link{setServer}} before this
-#' function.
+#' Authenticates with the server.
 #'
-#' For security reasons, you should not store your password in plain text, and
-#' you should ensure that your R history does not store your password. Instead,
-#' consider setting an environment variable and using something like
-#' \code{authenticate("myusername", Sys.getenv("API_PASSWORD"))}
+#' For security, you should not store your password in plain text, and you
+#' should ensure that your R history does not store your password. Instead,
+#' consider setting an environment variable (see examples).
 #'
 #' @param username Your username.
-#' @param password Your password.
+#' @param password Your password. If omitted and running in RStudio or the
+#' getPass library is installed, a prompt will be displayed.
+#' @param otp A one-time passcode, if your account is configured with two-factor
+#' authentication. If omitted and in an interactive session, a prompt will be
+#' displayed. Note that this must be a string.
 #' @export
 #' @examples
 #' \dontrun{
+#' # Use with caution, don't let prying eyes see your password.
 #' authenticate("username", "password")
+#' # Instead, you could store it in an environment variable.
+#' authenticate("username", Sys.getenv("API_PASSWORD"))
+#'
+#' # If the password is omitted and you're running in RStudio or the getPass
+#' library is installed, a prompt will be displayed.
+#' authenticate("username")
 #' }
-authenticate = function(username, password) {
-  body = jsonlite::toJSON(list(
+authenticate = function(username, password=NA, otp=NA) {
+  if (is.na(password)) {
+    if (requireNamespace("getPass")) {
+      password = getPass::getPass(msg = "Please enter your password", noblank=T)
+    } else if (rstudioapi::isAvailable()) {
+      password = rstudioapi.askForPassword()
+    }
+  }
+
+  body = list(
     username = jsonlite::unbox(username),
     password = jsonlite::unbox(password)
-  ))
-  return(invisible(basePost("signin", body, list())))
+  )
+
+  if (!is.na(otp)) {
+    if (!is.character(otp))
+      stop("OTP must be a string")
+
+    body$otp = jsonlite::unbox(otp)
+  }
+
+  ensureBaseUrl()
+  fullURL = paste(pkg.env$baseURL, "signin", sep = "/")
+  r = httr::POST(fullURL, body = jsonlite::toJSON(body),
+    httr::content_type_json(), httr::user_agent(ua))
+
+  if (httr::status_code(r) == 200)
+    return(invisible())
+
+  content = httr::content(r, "text", encoding = "UTF-8")
+  parsed = jsonlite::fromJSON(content)
+
+  if (httr::status_code(r) == 400 && parsed$error == '"otp" is required.') {
+    if (requireNamespace("getPass")) {
+      otp = getPass::getPass(msg = "Please enter your one-time code", noblank=T)
+    } else if (rstudioapi::isAvailable()) {
+      otp = rstudioapi.askForPassword("Please enter your one-time code")
+    } else if (interactive()) {
+      otp = readline("Please enter your one-time code");
+    }
+    authenticate(username, password, otp)
+  } else {
+    httr::stop_for_status(r)
+  }
 }

--- a/man/authenticate.Rd
+++ b/man/authenticate.Rd
@@ -4,25 +4,35 @@
 \alias{authenticate}
 \title{Authenticate}
 \usage{
-authenticate(username, password)
+authenticate(username, password = NA, otp = NA)
 }
 \arguments{
 \item{username}{Your username.}
 
-\item{password}{Your password.}
+\item{password}{Your password. If omitted and running in RStudio or the
+getPass library is installed, a prompt will be displayed.}
+
+\item{otp}{A one-time passcode, if your account is configured with two-factor
+authentication. If omitted and in an interactive session, a prompt will be
+displayed. Note that this must be a string.}
 }
 \description{
-Authenticates with the server. Call \code{\link{setServer}} before this
-function.
+Authenticates with the server.
 }
 \details{
-For security reasons, you should not store your password in plain text, and
-you should ensure that your R history does not store your password. Instead,
-consider setting an environment variable and using something like
-\code{authenticate("myusername", Sys.getenv("API_PASSWORD"))}
+For security, you should not store your password in plain text, and you
+should ensure that your R history does not store your password. Instead,
+consider setting an environment variable (see examples).
 }
 \examples{
 \dontrun{
+# Use with caution, don't let prying eyes see your password.
 authenticate("username", "password")
+# Instead, you could store it in an environment variable.
+authenticate("username", Sys.getenv("API_PASSWORD"))
+
+# If the password is omitted and you're running in RStudio or the getPass
+library is installed, a prompt will be displayed.
+authenticate("username")
 }
 }

--- a/tests/testthat/test-authenticate.R
+++ b/tests/testthat/test-authenticate.R
@@ -18,8 +18,30 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = authenticate("user1", "p@ssword")
-      expect_equal(resp$admin, FALSE)
+      authenticate("user1", "p@ssword")
+    }
+  )
+})
+
+test_that("Correct HTTP request is made with OTP", {
+  with_mock(
+    `httr::request_perform` = function(req, handle, refresh) {
+      expect_equal(req$method, "POST")
+      expect_equal(req$url, "https://my.server.com/api/v1/signin")
+      body = rawToChar(req$options$postfields)
+      expect_equal(body, '{"username":"user1","password":"p@ssword","otp":"012345"}')
+      response = httptest::fake_response(
+        req$url,
+        req$method,
+        content='{"token":"s:abcdefgh.ijklmnop/pqr","userId":"592799bd14ac0ad59699cb77","admin":false,"flags":{}}',
+        status_code = 200,
+        headers = list(`Content-Type` = "application/json")
+      )
+      return(response)
+    },
+    {
+      setServer("https://my.server.com")
+      authenticate("user1", "p@ssword", "012345")
     }
   )
 })


### PR DESCRIPTION
* Adds support for accounts with two-factor authentication.
* Automatically prompts for password and 2FA code when possible.

Fixes #55