### PR TITLE
feat: introduce lintr

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,7 +6,7 @@
 ^docs$
 ^_pkgdown.yml$
 ^_pkgdown\.yml$
-.github
+^\.github$
 CHANGELOG.md
 vignettes/
 ^\.lintr$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 .github
 CHANGELOG.md
 vignettes/
+^\.lintr$

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,49 @@
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+name: lint
+
+jobs:
+  lint:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Restore R package cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("lintr")
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}

--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,7 @@
 linters: with_defaults(
   line_length_linter(120), 
   commented_code_linter = NULL,
-  object_name_linter = object_name_linter("camelCase"),
+  object_name_linter = object_name_linter(c("camelCase", "snake_case")),
   open_curly_linter = NULL,
   closed_curly_linter = NULL,
   object_usage_linter = NULL,

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,12 @@
+linters: with_defaults(
+  line_length_linter(120), 
+  commented_code_linter = NULL,
+  object_name_linter = object_name_linter("camelCase"),
+  open_curly_linter = NULL,
+  closed_curly_linter = NULL,
+  object_usage_linter = NULL,
+  cyclocomp_linter = cyclocomp_linter(complexity_limit=25)
+  )
+exclude: "# nolint"
+exclude_start: "# start nolint"
+exclude_end: "# end nolint"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   running in RStudio or the `getPass` library is installed.
 - The `authenticate` function now supports two-factor authentication.
 - Support `byName()` for the `gateId` argument in `updateGate()`.
+- Introduce `lintr` as a linter with an Actions workflow
 
 ### Changed
 - Fix for [confusing bulk entity retrieval](https://github.com/primitybio/cellengine-r-toolkit/issues/48)
@@ -23,5 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix mangling of experiment properties in `updateGateFamily()`.
 - Fix mangling of experiment properties in `updateGate()`.
 - Remove unused `params` argument from `getExperiment()`.
+- Run `styler` on all files with default params
 
 ### Removed

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cellengine
 Type: Package
-Title: CellEngine API Toolkit
+Title: 'CellEngine' API Toolkit
 Version: 0.2.0
 Authors@R: c(
     person("Zach", "Bjornson", email = "zbjornson@primitybio.com", role = c("aut", "cre")),

--- a/R/annotateFcsFile.R
+++ b/R/annotateFcsFile.R
@@ -16,7 +16,8 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' annotations <- list(list(name = "annotations 1", value = 1), list(name = "annotation 2", value = "myValue"))
+#' annotations <- list(list(name = "annotations 1", value = 1),
+#'   list(name = "annotation 2", value = "myValue"))
 #' annotateFcsFile(experimentId, fcsFileId, annotations)
 #' }
 annotateFcsFile <- function(experimentId, fcsFileId, annotations) {

--- a/R/annotateFcsFile.R
+++ b/R/annotateFcsFile.R
@@ -16,14 +16,14 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' annotations = list(list(name="annotations 1", value=1), list(name="annotation 2", value="myValue"))
+#' annotations <- list(list(name = "annotations 1", value = 1), list(name = "annotation 2", value = "myValue"))
 #' annotateFcsFile(experimentId, fcsFileId, annotations)
 #' }
-annotateFcsFile = function(experimentId, fcsFileId, annotations) {
+annotateFcsFile <- function(experimentId, fcsFileId, annotations) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(fcsFileId)
-  fcsFileId = lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
-  body = jsonlite::toJSON(list("annotations" = annotations), auto_unbox = TRUE)
+  fcsFileId <- lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
+  body <- jsonlite::toJSON(list("annotations" = annotations), auto_unbox = TRUE)
   basePatch(paste("experiments", experimentId, "fcsfiles", fcsFileId, sep = "/"), body)
 }

--- a/R/applyScale.R
+++ b/R/applyScale.R
@@ -10,23 +10,29 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' applyScale(list(type='LinearScale', minimum=1, maximum=10), c(1, 2, 3, 4, 5))
+#' applyScale(list(type = "LinearScale", minimum = 1, maximum = 10), c(1, 2, 3, 4, 5))
 #'
 #' # Using a Scale from a CellEngine ScaleSet
-#' scaleSet = getScaleSets(experimentId)
-#' chanIdx = 5
+#' scaleSet <- getScaleSets(experimentId)
+#' chanIdx <- 5
 #' applyScale(scaleSet$scales[[1]][chanIdx, "scale"], c(1, 2, 3, 4, 5))
 #' }
-applyScale = function(scale, data, clamp_q=FALSE) {
-  fn = switch(
-    scale$type,
-    "LinearScale" = function(a) { a },
-    "LogScale" = function(a) { log10(pmax(1, a)) },
-    "ArcSinhScale" = function(a) { asinh(a / scale$cofactor) },
-    )
+applyScale <- function(scale, data, clamp_q = FALSE) {
+  fn <- switch(scale$type,
+    "LinearScale" = function(a) {
+      a
+    },
+    "LogScale" = function(a) {
+      log10(pmax(1, a))
+    },
+    "ArcSinhScale" = function(a) {
+      asinh(a / scale$cofactor)
+    },
+  )
 
-  if (clamp_q)
-    data = pmax(pmin(data, scale$maximum), scale$minimum)
+  if (clamp_q) {
+    data <- pmax(pmin(data, scale$maximum), scale$minimum)
+  }
 
   fn(data)
 }

--- a/R/authenticate.R
+++ b/R/authenticate.R
@@ -21,48 +21,52 @@
 #' authenticate("username", Sys.getenv("API_PASSWORD"))
 #'
 #' # If the password is omitted and you're running in RStudio or the getPass
-#' library is installed, a prompt will be displayed.
+#' # library is installed, a prompt will be displayed.
 #' authenticate("username")
 #' }
-authenticate = function(username, password=NA, otp=NA) {
+authenticate <- function(username, password = NA, otp = NA) {
   if (is.na(password)) {
     if (requireNamespace("getPass")) {
-      password = getPass::getPass(msg = "Please enter your password", noblank=T)
+      password <- getPass::getPass(msg = "Please enter your password", noblank = T)
     } else if (rstudioapi::isAvailable()) {
-      password = rstudioapi::askForPassword()
+      password <- rstudioapi::askForPassword()
     }
   }
 
-  body = list(
+  body <- list(
     username = jsonlite::unbox(username),
     password = jsonlite::unbox(password)
   )
 
   if (!is.na(otp)) {
-    if (!is.character(otp))
+    if (!is.character(otp)) {
       stop("OTP must be a string")
+    }
 
-    body$otp = jsonlite::unbox(otp)
+    body$otp <- jsonlite::unbox(otp)
   }
 
   ensureBaseUrl()
-  fullURL = paste(pkg.env$baseURL, "signin", sep = "/")
-  r = httr::POST(fullURL, body = jsonlite::toJSON(body),
-    httr::content_type_json(), httr::user_agent(ua))
+  fullURL <- paste(pkg.env$baseURL, "signin", sep = "/")
+  r <- httr::POST(fullURL,
+    body = jsonlite::toJSON(body),
+    httr::content_type_json(), httr::user_agent(ua)
+  )
 
-  if (httr::status_code(r) == 200)
+  if (httr::status_code(r) == 200) {
     return(invisible())
+  }
 
-  content = httr::content(r, "text", encoding = "UTF-8")
-  parsed = jsonlite::fromJSON(content)
+  content <- httr::content(r, "text", encoding = "UTF-8")
+  parsed <- jsonlite::fromJSON(content)
 
   if (httr::status_code(r) == 400 && parsed$error == '"otp" is required.') {
     if (requireNamespace("getPass")) {
-      otp = getPass::getPass(msg = "Please enter your one-time code", noblank=T)
+      otp <- getPass::getPass(msg = "Please enter your one-time code", noblank = T)
     } else if (rstudioapi::isAvailable()) {
-      otp = rstudioapi::askForPassword("Please enter your one-time code")
+      otp <- rstudioapi::askForPassword("Please enter your one-time code")
     } else if (interactive()) {
-      otp = readline("Please enter your one-time code");
+      otp <- readline("Please enter your one-time code")
     }
     authenticate(username, password, otp)
   } else {

--- a/R/createEllipseGate.R
+++ b/R/createEllipseGate.R
@@ -34,15 +34,14 @@
 #' \dontrun{
 #' createEllipseGate(experimentId, "FSC-A", "FSC-W", "my gate", c(1, 2, 3), c(4, 5, 6))
 #' }
-createEllipseGate = function(experimentId, xChannel, yChannel, name,
-                             x, y, angle, major, minor,
-                             label = c(x, y),
-                             gid = generateId(),
-                             parentPopulationId = NULL, parentPopulation = NULL,
-                             tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
-                             locked = FALSE, createPopulation = TRUE) {
-
-  body = list(
+createEllipseGate <- function(experimentId, xChannel, yChannel, name,
+                              x, y, angle, major, minor,
+                              label = c(x, y),
+                              gid = generateId(),
+                              parentPopulationId = NULL, parentPopulation = NULL,
+                              tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
+                              locked = FALSE, createPopulation = TRUE) {
+  body <- list(
     model = list(
       locked = jsonlite::unbox(locked),
       ellipse = list(
@@ -58,6 +57,8 @@ createEllipseGate = function(experimentId, xChannel, yChannel, name,
     type = jsonlite::unbox("EllipseGate")
   )
 
-  commonGateCreate(body, name, gid, experimentId, parentPopulationId, parentPopulation,
-    tailoredPerFile, fcsFileId, fcsFile, createPopulation)
+  commonGateCreate(
+    body, name, gid, experimentId, parentPopulationId, parentPopulation,
+    tailoredPerFile, fcsFileId, fcsFile, createPopulation
+  )
 }

--- a/R/createExperiment.R
+++ b/R/createExperiment.R
@@ -10,7 +10,7 @@
 #' createExperiment() # creates a blank experiment
 #' createExperiment(list("name" = "my experiment"))
 #' }
-createExperiment = function(properties = list(), params = list()) {
-  body = jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
+createExperiment <- function(properties = list(), params = list()) {
+  body <- jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
   basePost(paste("experiments", sep = "/"), body, params)
 }

--- a/R/createGates.R
+++ b/R/createGates.R
@@ -21,42 +21,48 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' g1 = list(type = "RectangleGate", xChannel = "FSC-A", yChannel = "SSC-A",
-#'   model = list(rectangle = list(x1 = 1, x2 = 100, y1 = 1, y2 = 100)))
-#' g2 = list(type = "PolygonGate", xChannel = "FSC-A", yChannel = "SSC-A",
-#'   model = list(polygon = list(vertices = c(c(1, 2), c(30, 40), c(50, 60)))))
-#' g3 = list(type = "RangeGate", xChannel = "V450-480-A",
-#'   model = list(range = list(x1 = 1, x2 = 100, y = 0.5)))
+#' g1 <- list(
+#'   type = "RectangleGate", xChannel = "FSC-A", yChannel = "SSC-A",
+#'   model = list(rectangle = list(x1 = 1, x2 = 100, y1 = 1, y2 = 100))
+#' )
+#' g2 <- list(
+#'   type = "PolygonGate", xChannel = "FSC-A", yChannel = "SSC-A",
+#'   model = list(polygon = list(vertices = c(c(1, 2), c(30, 40), c(50, 60))))
+#' )
+#' g3 <- list(
+#'   type = "RangeGate", xChannel = "V450-480-A",
+#'   model = list(range = list(x1 = 1, x2 = 100, y = 0.5))
+#' )
 #'
 #' createGates(experimentId, c(g1, g2, g3))
 #' }
-createGates = function(experimentId, gates) {
+createGates <- function(experimentId, gates) {
   # This function could be friendlier in terms of valdiating gates, but it is
   # an advanced function.
 
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
 
-  body = lapply(gates, function (g) {
+  body <- lapply(gates, function(g) {
     if (!("label" %in% names(g$model))) {
-      switch (g$type,
+      switch(g$type,
         RectangleGate = {
-          g$model$label = c(
+          g$model$label <- c(
             mean(c(g$model$rectangle$x1, g$model$rectangle$x2)),
             mean(c(g$model$rectangle$y1, g$model$rectangle$y2))
           )
         },
         PolygonGate = {
-          g$model$label = c(
-            mean(g$model$polygon$vertices[,1]),
-            mean(g$model$polygon$vertices[,2])
+          g$model$label <- c(
+            mean(g$model$polygon$vertices[, 1]),
+            mean(g$model$polygon$vertices[, 2])
           )
         },
         EllipseGate = {
-          g$model$label = c(g$model$center[1], g$model$center[2])
+          g$model$label <- c(g$model$center[1], g$model$center[2])
         },
         RangeGate = {
-          g$model$label = c(
+          g$model$label <- c(
             mean(g$model$range$x1, g$model$range$x2),
             g$model$range.y
           )
@@ -64,17 +70,17 @@ createGates = function(experimentId, gates) {
       )
     }
 
-    if (!("locked" %in% names(g["model"]))) g$model$locked = FALSE
+    if (!("locked" %in% names(g["model"]))) g$model$locked <- FALSE
 
-    if (!("gid" %in% names(g))) g["gid"] = generateId()
+    if (!("gid" %in% names(g))) g["gid"] <- generateId()
 
-    if (!("parentPopulationId" %in% names(g))) g["parentPopulationId"] = list(NULL)
+    if (!("parentPopulationId" %in% names(g))) g["parentPopulationId"] <- list(NULL)
 
-    if (!("tailoredPerFile" %in% names(g))) g["tailoredPerFile"] = FALSE
+    if (!("tailoredPerFile" %in% names(g))) g["tailoredPerFile"] <- FALSE
 
     g
   })
 
-  body = jsonlite::toJSON(body, null = "null", auto_unbox = TRUE)
+  body <- jsonlite::toJSON(body, null = "null", auto_unbox = TRUE)
   basePost(paste("experiments", experimentId, "gates", sep = "/"), body)
 }

--- a/R/createPolygonGate.R
+++ b/R/createPolygonGate.R
@@ -34,26 +34,25 @@
 #' \dontrun{
 #' createPolygonGate(experimentId, "FSC-A", "FSC-W", "my gate", c(1, 2, 3), c(4, 5, 6))
 #' }
-createPolygonGate = function(experimentId, xChannel, yChannel, name,
-                             vertices = list(),
-                             xVertices = c(), yVertices = c(),
-                             label = NULL,
-                             gid = generateId(),
-                             parentPopulationId = NULL, parentPopulation = NULL,
-                             tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
-                             locked = FALSE, createPopulation = TRUE) {
-
+createPolygonGate <- function(experimentId, xChannel, yChannel, name,
+                              vertices = list(),
+                              xVertices = c(), yVertices = c(),
+                              label = NULL,
+                              gid = generateId(),
+                              parentPopulationId = NULL, parentPopulation = NULL,
+                              tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
+                              locked = FALSE, createPopulation = TRUE) {
   if (length(vertices) > 0) {
-    label = c(mean(sapply(vertices, "[[", 1)), mean(sapply(vertices, "[[", 2)))
-    vertices = do.call(rbind, vertices)
+    label <- c(mean(sapply(vertices, "[[", 1)), mean(sapply(vertices, "[[", 2)))
+    vertices <- do.call(rbind, vertices)
   } else if (length(xVertices) > 0 & length(yVertices) > 0) {
-    label = c(mean(xVertices), mean(yVertices))
-    vertices = matrix(c(xVertices, yVertices), ncol = 2)
+    label <- c(mean(xVertices), mean(yVertices))
+    vertices <- matrix(c(xVertices, yVertices), ncol = 2)
   } else {
     stop("Either vertices or both xVertices and yVertices must be specified")
   }
 
-  body = list(
+  body <- list(
     model = list(
       locked = jsonlite::unbox(locked),
       polygon = list(
@@ -66,6 +65,8 @@ createPolygonGate = function(experimentId, xChannel, yChannel, name,
     type = jsonlite::unbox("PolygonGate")
   )
 
-  commonGateCreate(body, name, gid, experimentId, parentPopulationId, parentPopulation,
-    tailoredPerFile, fcsFileId, fcsFile, createPopulation)
+  commonGateCreate(
+    body, name, gid, experimentId, parentPopulationId, parentPopulation,
+    tailoredPerFile, fcsFileId, fcsFile, createPopulation
+  )
 }

--- a/R/createPopulation.R
+++ b/R/createPopulation.R
@@ -22,17 +22,16 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' gid1 = "59262d84b1a1fc1193f12b0e"
+#' gid1 <- "59262d84b1a1fc1193f12b0e"
 #' createPopulation(experimentId, "Singlets", list(`$and` = c(gid1)), gid1)
 #' }
-createPopulation = function(experimentId, name, gates, terminalGateGid,
-                            parentId = NULL) {
-
+createPopulation <- function(experimentId, name, gates, terminalGateGid,
+                             parentId = NULL) {
   checkDefined(experimentId)
 
-  if (!is.character(gates)) gates = jsonlite::toJSON(gates)
+  if (!is.character(gates)) gates <- jsonlite::toJSON(gates)
 
-  body = jsonlite::toJSON(list(
+  body <- jsonlite::toJSON(list(
     name = jsonlite::unbox(name),
     gates = jsonlite::unbox(gates),
     terminalGateGid = jsonlite::unbox(terminalGateGid),

--- a/R/createQuadrantGate.R
+++ b/R/createQuadrantGate.R
@@ -37,40 +37,48 @@
 #' \dontrun{
 #' createQuadrantGate(experimentId, "FSC-A", "FSC-W", "my gate", 160000, 200000)
 #' }
-createQuadrantGate = function(experimentId, xChannel, yChannel, name,
+createQuadrantGate <- function(experimentId, xChannel, yChannel, name,
                                x, y, labels = NULL,
                                gid = generateId(), gids = replicate(4, generateId()),
                                parentPopulationId = NULL, parentPopulation = NULL,
                                tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
                                locked = FALSE, createPopulations = TRUE) {
-  #future args:
-  skewable = FALSE
-  angles = c(pi/2, pi, 3/2*pi, 0.000000)
-# @param angles Angles at which the quadrant lines appear, in radians.
-# Zero (0) points horizontally to the right; angles proceed counter-clockwise.
-# Currently these must be 0, pi / 2, pi and 3 * pi / 2.
+  # future args:
+  skewable <- FALSE
+  angles <- c(pi / 2, pi, 3 / 2 * pi, 0.000000)
+  # @param angles Angles at which the quadrant lines appear, in radians.
+  # Zero (0) points horizontally to the right; angles proceed counter-clockwise.
+  # Currently these must be 0, pi / 2, pi and 3 * pi / 2.
 
   if (length(labels) == 0) {
-    scales = data.frame(getScaleSets(experimentId)$scales)
-    labels = list(
-               c(scales[scales$channelName==xChannel, ]$scale$maximum, # upper right
-               scales[scales$channelName==yChannel, ]$scale$maximum), # upper right
-               c(scales[scales$channelName==xChannel, ]$scale$minimum, # upper left
-               scales[scales$channelName==yChannel, ]$scale$maximum), # upper left
-               c(scales[scales$channelName==xChannel, ]$scale$minimum, # lower left
-               scales[scales$channelName==yChannel, ]$scale$minimum),  # lower left
-               c(scales[scales$channelName==xChannel, ]$scale$maximum, # lower right
-               scales[scales$channelName==yChannel, ]$scale$minimum)  # lower right
-               )
-  } else if (all(dim(data.frame(labels)) == list(2,4))){
-    labels = labels
+    scales <- data.frame(getScaleSets(experimentId)$scales)
+    labels <- list(
+      c(
+        scales[scales$channelName == xChannel, ]$scale$maximum, # upper right
+        scales[scales$channelName == yChannel, ]$scale$maximum
+      ), # upper right
+      c(
+        scales[scales$channelName == xChannel, ]$scale$minimum, # upper left
+        scales[scales$channelName == yChannel, ]$scale$maximum
+      ), # upper left
+      c(
+        scales[scales$channelName == xChannel, ]$scale$minimum, # lower left
+        scales[scales$channelName == yChannel, ]$scale$minimum
+      ), # lower left
+      c(
+        scales[scales$channelName == xChannel, ]$scale$maximum, # lower right
+        scales[scales$channelName == yChannel, ]$scale$minimum
+      ) # lower right
+    )
+  } else if (all(dim(data.frame(labels)) == list(2, 4))) {
+    labels <- labels
   } else {
-    stop('Labels must be a list of 4 length-2 vectors.')
+    stop("Labels must be a list of 4 length-2 vectors.")
   }
 
-  names = paste(name, (c("(UR)", "(UL)", "(LL)", "(LR)")))
+  names <- paste(name, (c("(UR)", "(UL)", "(LL)", "(LR)")))
 
-  body = list(
+  body <- list(
     model = list(
       locked = jsonlite::unbox(locked),
       quadrant = list(
@@ -88,6 +96,8 @@ createQuadrantGate = function(experimentId, xChannel, yChannel, name,
     type = jsonlite::unbox("QuadrantGate")
   )
 
-  compoundGateCreate(body, names, gid, gids, experimentId, parentPopulationId, parentPopulation,
-    tailoredPerFile, fcsFileId, fcsFile, createPopulations)
+  compoundGateCreate(
+    body, names, gid, gids, experimentId, parentPopulationId, parentPopulation,
+    tailoredPerFile, fcsFileId, fcsFile, createPopulations
+  )
 }

--- a/R/createRangeGate.R
+++ b/R/createRangeGate.R
@@ -32,15 +32,14 @@
 #' \dontrun{
 #' createRangeGate(experimentId, "FSC-A", "my gate", 12.502, 95.102)
 #' }
-createRangeGate = function(experimentId, xChannel, name,
-                           x1, x2, y = 0.5,
-                           label = c(mean(c(x1, x2)), y),
-                           gid = generateId(),
-                           parentPopulationId = NULL, parentPopulation = NULL,
-                           tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
-                           locked = FALSE, createPopulation = TRUE) {
-
-  body = list(
+createRangeGate <- function(experimentId, xChannel, name,
+                            x1, x2, y = 0.5,
+                            label = c(mean(c(x1, x2)), y),
+                            gid = generateId(),
+                            parentPopulationId = NULL, parentPopulation = NULL,
+                            tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
+                            locked = FALSE, createPopulation = TRUE) {
+  body <- list(
     model = list(
       locked = jsonlite::unbox(locked),
       range = list(
@@ -54,6 +53,8 @@ createRangeGate = function(experimentId, xChannel, name,
     type = jsonlite::unbox("RangeGate")
   )
 
-  commonGateCreate(body, name, gid, experimentId, parentPopulationId, parentPopulation,
-    tailoredPerFile, fcsFileId, fcsFile, createPopulation)
+  commonGateCreate(
+    body, name, gid, experimentId, parentPopulationId, parentPopulation,
+    tailoredPerFile, fcsFileId, fcsFile, createPopulation
+  )
 }

--- a/R/createRectangleGate.R
+++ b/R/createRectangleGate.R
@@ -33,15 +33,14 @@
 #' \dontrun{
 #' createRectangleGate(experimentId, "FSC-A", "FSC-W", "my gate", 12.502, 95.102, 1020, 32021.2)
 #' }
-createRectangleGate = function(experimentId, xChannel, yChannel, name,
-                               x1, x2, y1, y2,
-                               label = c(mean(c(x1, x2)), mean(c(y1, y2))),
-                               gid = generateId(),
-                               parentPopulationId = NULL, parentPopulation = NULL,
-                               tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
-                               locked = FALSE, createPopulation = TRUE) {
-
-  body = list(
+createRectangleGate <- function(experimentId, xChannel, yChannel, name,
+                                x1, x2, y1, y2,
+                                label = c(mean(c(x1, x2)), mean(c(y1, y2))),
+                                gid = generateId(),
+                                parentPopulationId = NULL, parentPopulation = NULL,
+                                tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
+                                locked = FALSE, createPopulation = TRUE) {
+  body <- list(
     model = list(
       locked = jsonlite::unbox(locked),
       rectangle = list(
@@ -57,6 +56,8 @@ createRectangleGate = function(experimentId, xChannel, yChannel, name,
     type = jsonlite::unbox("RectangleGate")
   )
 
-  commonGateCreate(body, name, gid, experimentId, parentPopulationId, parentPopulation,
-    tailoredPerFile, fcsFileId, fcsFile, createPopulation)
+  commonGateCreate(
+    body, name, gid, experimentId, parentPopulationId, parentPopulation,
+    tailoredPerFile, fcsFileId, fcsFile, createPopulation
+  )
 }

--- a/R/createSplitGate.R
+++ b/R/createSplitGate.R
@@ -37,32 +37,32 @@
 #' \dontrun{
 #' createSplitGate(experimentId, "FSC-A", "my gate", 144000, 100000)
 #' }
-createSplitGate = function(experimentId, xChannel, name, x, y=0.5,
-                               gid = generateId(), gids = replicate(2, generateId()), labels = NULL,
-                               parentPopulationId = NULL, parentPopulation = NULL,
-                               tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
-                               locked = FALSE, createPopulation = TRUE) {
+createSplitGate <- function(experimentId, xChannel, name, x, y = 0.5,
+                            gid = generateId(), gids = replicate(2, generateId()), labels = NULL,
+                            parentPopulationId = NULL, parentPopulation = NULL,
+                            tailoredPerFile = FALSE, fcsFileId = NULL, fcsFile = NULL,
+                            locked = FALSE, createPopulation = TRUE) {
 
 
 
   # set labels based on axis scale
   if (length(labels) == 0) {
-    scales = data.frame(getScaleSets(experimentId)$scales)
-    min = scales[scales$channelName==xChannel, ]$scale$minimum
-    max = scales[scales$channelName==xChannel, ]$scale$maximum
-    labels = list(
-      c(min + 0.1*max, 0.95),
-      c(max - 0.1*max, 0.95)
-      )
-  } else if (all(dim(data.frame(labels)) == list(2,2))){
-    labels = labels
+    scales <- data.frame(getScaleSets(experimentId)$scales)
+    min <- scales[scales$channelName == xChannel, ]$scale$minimum
+    max <- scales[scales$channelName == xChannel, ]$scale$maximum
+    labels <- list(
+      c(min + 0.1 * max, 0.95),
+      c(max - 0.1 * max, 0.95)
+    )
+  } else if (all(dim(data.frame(labels)) == list(2, 2))) {
+    labels <- labels
   } else {
-    stop('Labels must be a list of 2 length-2 vectors.')
+    stop("Labels must be a list of 2 length-2 vectors.")
   }
 
-  names = paste(name, (c("(L)", "(R)")))
+  names <- paste(name, (c("(L)", "(R)")))
 
-  body = list(
+  body <- list(
     model = list(
       locked = jsonlite::unbox(locked),
       split = list(
@@ -77,6 +77,8 @@ createSplitGate = function(experimentId, xChannel, name, x, y=0.5,
     type = jsonlite::unbox("SplitGate")
   )
 
-  compoundGateCreate(body, names, gid, gids, experimentId, parentPopulationId, parentPopulation,
-    tailoredPerFile, fcsFileId, fcsFile, createPopulation)
+  compoundGateCreate(
+    body, names, gid, gids, experimentId, parentPopulationId, parentPopulation,
+    tailoredPerFile, fcsFileId, fcsFile, createPopulation
+  )
 }

--- a/R/deleteExperiment.R
+++ b/R/deleteExperiment.R
@@ -8,8 +8,8 @@
 #' \dontrun{
 #' deleteExperiment(experimentId)
 #' }
-deleteExperiment = function(experimentId) {
+deleteExperiment <- function(experimentId) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   baseDelete(paste("experiments", experimentId, sep = "/"))
 }

--- a/R/deleteFcsFile.R
+++ b/R/deleteFcsFile.R
@@ -9,10 +9,10 @@
 #' \dontrun{
 #' deleteFcsFile(experimentId, fcsFileId)
 #' }
-deleteFcsFile = function(experimentId, fcsFileId) {
+deleteFcsFile <- function(experimentId, fcsFileId) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(fcsFileId)
-  fcsFileId = lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
+  fcsFileId <- lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
   baseDelete(paste("experiments", experimentId, "fcsfiles", fcsFileId, sep = "/"))
 }

--- a/R/deleteGates.R
+++ b/R/deleteGates.R
@@ -23,27 +23,25 @@
 #' deleteGate(experimentId, gid = gateFamilyID)
 #' deleteGate(experimentId, gateId = gateID)
 #' }
-
-deleteGates = function(experimentId, gid = NULL, gateId = NULL, exclude = NULL) {
+#'
+deleteGates <- function(experimentId, gid = NULL, gateId = NULL, exclude = NULL) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
-  base = paste("experiments", experimentId, "gates", sep = "/")
-  #TODO:(ge) Add byName functionality for gateId
+  experimentId <- lookupByName("experiments", experimentId)
+  base <- paste("experiments", experimentId, "gates", sep = "/")
+  # TODO:(ge) Add byName functionality for gateId
 
-  if ((is.null(gid) & is.null(gateId)) | (!is.null(gid) & !is.null(gateId))){
-
-      stop("Either the gid or the gateId must be specified")
+  if ((is.null(gid) & is.null(gateId)) | (!is.null(gid) & !is.null(gateId))) {
+    stop("Either the gid or the gateId must be specified")
   }
 
-  if (!is.null(gateId)){
+  if (!is.null(gateId)) {
     checkDefined(gateId)
-    url = sprintf("%s/%s", base, gateId)
+    url <- sprintf("%s/%s", base, gateId)
   } else if (!is.null(gid)) {
-    url = sprintf("%s?gid=%s", base, gid)
+    url <- sprintf("%s?gid=%s", base, gid)
     if (!is.null(exclude)) {
-        url = sprintf("$s&exclude=%s", url, exclude)
+      url <- sprintf("$s&exclude=%s", url, exclude)
     }
   }
   baseDelete(url)
 }
-

--- a/R/deletePopulationAuto.R
+++ b/R/deletePopulationAuto.R
@@ -10,11 +10,11 @@
 #' \dontrun{
 #' deletePopulationAuto(experimentId, populationId)
 #' }
-deletePopulationAuto = function(experimentId, populationId) {
+deletePopulationAuto <- function(experimentId, populationId) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(populationId)
-  populationId = lookupByName(paste("experiments", experimentId, "populations", sep = "/"), populationId)
+  populationId <- lookupByName(paste("experiments", experimentId, "populations", sep = "/"), populationId)
   baseDelete(
     paste("experiments", experimentId, "populations", populationId, sep = "/"),
     params = list(deleteBranch = "true")

--- a/R/downloadAttachment.R
+++ b/R/downloadAttachment.R
@@ -12,7 +12,7 @@
 #' @examples
 #' \dontrun{
 #' # Returns the attachment as a binary blob:
-#' attachment = downloadAttachment(experimentId, attachmentId)
+#' attachment <- downloadAttachment(experimentId, attachmentId)
 #' # Parse it as text:
 #' readBin(attachment, character())
 #'
@@ -22,26 +22,25 @@
 #' # Use the byName helper to avoid finding the attachment ID:
 #' downloadAttachment(experimentId, byName("file.txt"))
 #' }
-downloadAttachment = function(experimentId,
-                     attachmentId,
-                     destination = NULL,
-                     overwrite = FALSE) {
-
+downloadAttachment <- function(experimentId,
+                               attachmentId,
+                               destination = NULL,
+                               overwrite = FALSE) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(attachmentId)
-  attachmentId = lookupByName(paste("experiments", experimentId, "attachments", sep = "/"), attachmentId, "filename")
+  attachmentId <- lookupByName(paste("experiments", experimentId, "attachments", sep = "/"), attachmentId, "filename")
   ensureBaseUrl()
 
-  fullURL = paste(pkg.env$baseURL, "experiments", experimentId, "attachments", attachmentId, sep = "/")
+  fullURL <- paste(pkg.env$baseURL, "experiments", experimentId, "attachments", attachmentId, sep = "/")
 
   if (is.null(destination)) {
-    response = httr::GET(fullURL, httr::user_agent(ua))
+    response <- httr::GET(fullURL, httr::user_agent(ua))
     httr::stop_for_status(response, "download attachment")
-    content = httr::content(response, "raw")
+    content <- httr::content(response, "raw")
     return(content)
   } else {
-    response = httr::GET(fullURL, httr::user_agent(ua), httr::write_disk(destination, overwrite))
+    response <- httr::GET(fullURL, httr::user_agent(ua), httr::write_disk(destination, overwrite))
     httr::stop_for_status(response, "download attachment")
   }
 }

--- a/R/downloadFcsFiles.R
+++ b/R/downloadFcsFiles.R
@@ -38,26 +38,25 @@
 #' # Download all FCS files in the experiment
 #' downloadFcsFiles(experimentId, "fcs", "archive.zip", overwrite = T)
 #' # Download specific FCS files
-#' fcsFileIds=c("5d2f8b4b21fd0676fb3a6a72", "5d2f8b4b21fd0676fb3a6a74")
-#' downloadFcsFiles(experimentId, "fcs", "archive.zip", fcsFileIds=fcsFileIds)
+#' fcsFileIds <- c("5d2f8b4b21fd0676fb3a6a72", "5d2f8b4b21fd0676fb3a6a74")
+#' downloadFcsFiles(experimentId, "fcs", "archive.zip", fcsFileIds = fcsFileIds)
 #' }
-downloadFcsFiles <- function(
-  experimentId,
-  format,
-  destination,
-  overwrite=F,
-  fcsFileIds=NULL,
-  populationIds=NULL,
-  compensationId=NULL,
-  compensatedQ=NULL,
-  preSubsampleN=NULL,
-  preSubsampleP=NULL,
-  postSubsampleN=NULL,
-  postSubsampleP=NULL,
-  seed=NULL,
-  filenameTemplate=NULL) {
+downloadFcsFiles <- function(experimentId,
+                             format,
+                             destination,
+                             overwrite = F,
+                             fcsFileIds = NULL,
+                             populationIds = NULL,
+                             compensationId = NULL,
+                             compensatedQ = NULL,
+                             preSubsampleN = NULL,
+                             preSubsampleP = NULL,
+                             postSubsampleN = NULL,
+                             postSubsampleP = NULL,
+                             seed = NULL,
+                             filenameTemplate = NULL) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
 
   body <- list(
     format = jsonlite::unbox(format),
@@ -72,7 +71,7 @@ downloadFcsFiles <- function(
     seed = jsonlite::unbox(seed),
     filenameTemplate = jsonlite::unbox(filenameTemplate)
   )
-  body <- body[-which(lapply(body,is.null) == T)]
+  body <- body[-which(lapply(body, is.null) == T)]
   body <- jsonlite::toJSON(body, null = "null", digits = NA)
 
   fullURL <- paste(
@@ -80,7 +79,8 @@ downloadFcsFiles <- function(
       pkg.env$baseURL,
       "experiments",
       experimentId,
-      "fcsfiles", "zip", sep = "/"
+      "fcsfiles", "zip",
+      sep = "/"
     ),
     sep = "."
   )

--- a/R/gateUtil.R
+++ b/R/gateUtil.R
@@ -1,11 +1,11 @@
 # Returns _id of population,using either of the parentPopulationId or parentPopulation params.
-parsePopulationArgs = function(parentPopulationId, parentPopulation, experimentId) {
+parsePopulationArgs <- function(parentPopulationId, parentPopulation, experimentId) {
   if (!is.null(parentPopulationId) && !is.null(parentPopulation)) {
     stop("Please specify only one of 'parentPopulation' or 'parentPopulationId'.")
   }
 
   if (!is.null(parentPopulation)) { # attempt to lookup by name
-    pops = getPopulations(experimentId, params = list(
+    pops <- getPopulations(experimentId, params = list(
       query = sprintf("eq(name, \"%s\")", parentPopulation)
     ))
     if (!is.data.frame(pops)) {
@@ -14,27 +14,32 @@ parsePopulationArgs = function(parentPopulationId, parentPopulation, experimentI
     if (nrow(pops) > 1) {
       stop(sprintf(paste0(
         "More than one population with the name '%s' exists in the experiment. ",
-        "Cannot find unambiguous parent population."), parentPopulation))
+        "Cannot find unambiguous parent population."
+      ), parentPopulation))
     }
-    parentPopulationId = pops$`_id`
+    parentPopulationId <- pops$`_id`
   }
 
   return(parentPopulationId)
 }
 
 # Assigns fcsFileId to body, using either of the fcsFileId or fcsFile params.
-parseFcsFileArgs = function(body, tailoredPerFile, fcsFileId, fcsFile, experimentId) {
-  body = c(body, list(tailoredPerFile = jsonlite::unbox(tailoredPerFile)))
+parseFcsFileArgs <- function(body, tailoredPerFile, fcsFileId, fcsFile, experimentId) {
+  body <- c(body, list(tailoredPerFile = jsonlite::unbox(tailoredPerFile)))
 
-  if (!tailoredPerFile) return(body) # not tailored
-  if (is.null(fcsFileId) && is.null(fcsFile)) return(body) # global tailored gate
-  
+  if (!tailoredPerFile) {
+    return(body)
+  } # not tailored
+  if (is.null(fcsFileId) && is.null(fcsFile)) {
+    return(body)
+  } # global tailored gate
+
   if (!is.null(fcsFileId) && !is.null(fcsFile)) {
     stop("Please specify only one of 'fcsFile' or 'fcsFileId'.")
   }
 
   if (!is.null(fcsFile)) { # attempt to lookup by name
-    files = getFcsFiles(experimentId, params = list(
+    files <- getFcsFiles(experimentId, params = list(
       query = sprintf("eq(filename, \"%s\")", fcsFile),
       fields = "+_id"
     ))
@@ -44,76 +49,78 @@ parseFcsFileArgs = function(body, tailoredPerFile, fcsFileId, fcsFile, experimen
     if (nrow(files) > 1) {
       stop(sprintf(paste0(
         "More than one FCS file with the name '%s' exists in the experiment. ",
-        "Cannot find unambiguous file to create tailored gate."), fcsFile))
+        "Cannot find unambiguous file to create tailored gate."
+      ), fcsFile))
     }
-    fcsFileId = files$`_id`
+    fcsFileId <- files$`_id`
   }
 
-  body = c(body, list(fcsFileId = jsonlite::unbox(fcsFileId)))
+  body <- c(body, list(fcsFileId = jsonlite::unbox(fcsFileId)))
 
   return(body)
 }
 
 # Assigns common properties to the body, then makes the request.
-commonGateCreate = function(body, name, gid,
-                            experimentId,
-                            parentPopulationId, parentPopulation,
-                            tailoredPerFile, fcsFileId, fcsFile,
-                            createPopulation) {
-
+commonGateCreate <- function(body, name, gid,
+                             experimentId,
+                             parentPopulationId, parentPopulation,
+                             tailoredPerFile, fcsFileId, fcsFile,
+                             createPopulation) {
   checkDefined(experimentId)
 
-  parentPopulationId = parsePopulationArgs(parentPopulationId, parentPopulation,
-    experimentId)
+  parentPopulationId <- parsePopulationArgs(
+    parentPopulationId, parentPopulation,
+    experimentId
+  )
 
-  body = c(body, list(
+  body <- c(body, list(
     parentPopulationId = jsonlite::unbox(parentPopulationId),
     name = jsonlite::unbox(name),
     gid = jsonlite::unbox(gid)
   ))
 
-  body = parseFcsFileArgs(body, tailoredPerFile, fcsFileId, fcsFile, experimentId)
+  body <- parseFcsFileArgs(body, tailoredPerFile, fcsFileId, fcsFile, experimentId)
 
-  body = jsonlite::toJSON(body, null = "null", digits = NA)
-  path = paste("experiments", experimentId, "gates", sep = "/")
+  body <- jsonlite::toJSON(body, null = "null", digits = NA)
+  path <- paste("experiments", experimentId, "gates", sep = "/")
 
   if (createPopulation) {
-      gateResp = basePost(path, body, params=list("createPopulation"=TRUE))
-      return(gateResp)
+    gateResp <- basePost(path, body, params = list("createPopulation" = TRUE))
+    return(gateResp)
   } else {
-      gateResp = basePost(path, body, list())
-      return(list(gate = gateResp))
+    gateResp <- basePost(path, body, list())
+    return(list(gate = gateResp))
   }
 }
 
 # Assigns common properties to body of compound gate, then makes the request.
-compoundGateCreate = function(body, names, gid, gids,
-                            experimentId,
-                            parentPopulationId, parentPopulation,
-                            tailoredPerFile, fcsFileId, fcsFile,
-                            createPopulation) {
-
+compoundGateCreate <- function(body, names, gid, gids,
+                               experimentId,
+                               parentPopulationId, parentPopulation,
+                               tailoredPerFile, fcsFileId, fcsFile,
+                               createPopulation) {
   checkDefined(experimentId)
 
-  parentPopulationId = parsePopulationArgs(parentPopulationId, parentPopulation,
-    experimentId)
+  parentPopulationId <- parsePopulationArgs(
+    parentPopulationId, parentPopulation,
+    experimentId
+  )
 
-  body = c(body, list(
+  body <- c(body, list(
     parentPopulationId = jsonlite::unbox(parentPopulationId),
     gid = jsonlite::unbox(gid)
   ))
 
-  body = parseFcsFileArgs(body, tailoredPerFile, fcsFileId, fcsFile, experimentId)
+  body <- parseFcsFileArgs(body, tailoredPerFile, fcsFileId, fcsFile, experimentId)
 
-  body = jsonlite::toJSON(body, null = "null", digits = NA)
-  path = paste("experiments", experimentId, "gates", sep = "/")
-  
+  body <- jsonlite::toJSON(body, null = "null", digits = NA)
+  path <- paste("experiments", experimentId, "gates", sep = "/")
+
   if (createPopulation) {
-      gateResp = basePost(path, body, params=list("createPopulation"=TRUE))
-      return(gateResp)
+    gateResp <- basePost(path, body, params = list("createPopulation" = TRUE))
+    return(gateResp)
   } else {
-      gateResp = basePost(path, body, list())
-      return(list(gate = gateResp))
+    gateResp <- basePost(path, body, list())
+    return(list(gate = gateResp))
   }
 }
-

--- a/R/generateId.R
+++ b/R/generateId.R
@@ -6,22 +6,24 @@
 #' @export
 #' @examples
 #' generateId()
-generateId = (function () {
-  seg1 = floor(runif(1, min = 0, max = 0xFFFFFF))
-  seg2 = floor(runif(1, min = 0, max = 0xFFFF))
-  incr = floor(runif(1, min = 0, max = 0xFFFFFF))
+generateId <- (function() {
+  seg1 <- floor(runif(1, min = 0, max = 0xFFFFFF))
+  seg2 <- floor(runif(1, min = 0, max = 0xFFFF))
+  incr <- floor(runif(1, min = 0, max = 0xFFFFFF))
 
   function() {
-    time = as.integer(Sys.time())
+    time <- as.integer(Sys.time())
     incr <<- incr + 1
-    if (incr > 0xFFFFFF) { incr = 0 }
+    if (incr > 0xFFFFFF) {
+      incr <- 0
+    }
 
-    timeStr = format(as.hexmode(time), width = 8)
-    seg1Str = format(as.hexmode(seg1), width = 6)
-    seg2Str = format(as.hexmode(seg2), width = 4)
-    incrStr = format(as.hexmode(incr), width = 6)
+    timeStr <- format(as.hexmode(time), width = 8)
+    seg1Str <- format(as.hexmode(seg1), width = 6)
+    seg2Str <- format(as.hexmode(seg2), width = 4)
+    incrStr <- format(as.hexmode(incr), width = 6)
 
-    id = paste(timeStr, seg1Str, seg2Str, incrStr, sep = "")
+    id <- paste(timeStr, seg1Str, seg2Str, incrStr, sep = "")
     return(id)
   }
 })()

--- a/R/getAttachments.R
+++ b/R/getAttachments.R
@@ -10,8 +10,8 @@
 #' getAttachments(experimentId)
 #' getAttachments(experimentId, params = list("limit" = "5"))
 #' }
-getAttachments = function(experimentId, params = list()) {
+getAttachments <- function(experimentId, params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   baseGet(paste("experiments", experimentId, "attachments", sep = "/"), params)
 }

--- a/R/getCompensations.R
+++ b/R/getCompensations.R
@@ -10,8 +10,8 @@
 #' getCompensations(experimentId)
 #' getCompensations(experimentId, params = list("limit" = "5"))
 #' }
-getCompensations = function(experimentId, params = list()) {
+getCompensations <- function(experimentId, params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   baseGet(paste("experiments", experimentId, "compensations", sep = "/"), params)
 }

--- a/R/getEvents.R
+++ b/R/getEvents.R
@@ -47,24 +47,23 @@
 #' getEvents(experimentId, fcsFileId, destination = "/path/to/output.tsv", format = "TSV", headerQ = T)
 #'
 #' # Subsamples and gates to only contain events in the specified population:
-#' subsampling = list(preSubsampleN = 5000, seed = 1.5)
+#' subsampling <- list(preSubsampleN = 5000, seed = 1.5)
 #' getEvents(experimentId, fcsFileId, populationId, subsampling = subsampling)
 #' }
-getEvents = function(experimentId,
-                     fcsFileId,
-                     populationId = NULL,
-                     compensation = NULL,
-                     compensatedQ = FALSE,
-                     headerQ = FALSE,
-                     format = "FCS",
-                     destination = NULL,
-                     overwrite = FALSE,
-                     subsampling = list()) {
-
+getEvents <- function(experimentId,
+                      fcsFileId,
+                      populationId = NULL,
+                      compensation = NULL,
+                      compensatedQ = FALSE,
+                      headerQ = FALSE,
+                      format = "FCS",
+                      destination = NULL,
+                      overwrite = FALSE,
+                      subsampling = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(fcsFileId)
-  fcsFileId = lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
+  fcsFileId <- lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
 
   if (is.null(compensation) && !is.null(populationId)) {
     stop("'compensation' parameter is required for gated populations.")
@@ -81,37 +80,41 @@ getEvents = function(experimentId,
   }
 
   if (!is.null(populationId)) {
-    populationId = lookupByName(paste("experiments", experimentId, "populations", sep = "/"), populationId)
+    populationId <- lookupByName(paste("experiments", experimentId, "populations", sep = "/"), populationId)
   }
 
   ensureBaseUrl()
 
-  fullURL = paste(paste(pkg.env$baseURL, "experiments", experimentId, "fcsfiles", fcsFileId, sep = "/"), format, sep = ".")
+  fullURL <- paste(
+    paste(pkg.env$baseURL, "experiments", experimentId, "fcsfiles", fcsFileId, sep = "/"),
+    format, sep = "."
+  )
 
-  params = list(
+  params <- list(
     populationId = populationId,
     compensationId = compensation,
     compensatedQ = compensatedQ,
     headers = headerQ
   )
 
-  subsamplingParams = Filter(Negate(is.null), subsampling[
-    c("preSubsampleN", "preSubsampleP", "postSubsampleN", "postSubsampleP", "seed")])
+  subsamplingParams <- Filter(Negate(is.null), subsampling[
+    c("preSubsampleN", "preSubsampleP", "postSubsampleN", "postSubsampleP", "seed")
+  ])
 
-  params = c(params, subsamplingParams)
+  params <- c(params, subsamplingParams)
 
   if (is.null(destination)) {
-    response = httr::GET(fullURL, query = params, httr::user_agent(ua))
+    response <- httr::GET(fullURL, query = params, httr::user_agent(ua))
     httr::warn_for_status(response)
     if (format == "TSV") {
-      content = httr::content(response, "text")
-      content = utils::read.table(text = content, header = headerQ, sep = "\t")
+      content <- httr::content(response, "text")
+      content <- utils::read.table(text = content, header = headerQ, sep = "\t")
     } else {
-      content = httr::content(response, "raw")
+      content <- httr::content(response, "raw")
     }
     return(content)
   } else {
-    response = httr::GET(fullURL, query = params, httr::user_agent(ua), httr::write_disk(destination, overwrite))
+    response <- httr::GET(fullURL, query = params, httr::user_agent(ua), httr::write_disk(destination, overwrite))
     httr::warn_for_status(response)
   }
 }

--- a/R/getExperiment.R
+++ b/R/getExperiment.R
@@ -12,8 +12,8 @@
 #' # Lookup by name
 #' getExperiment(byName("my experiment"))
 #' }
-getExperiment = function(experimentId) {
+getExperiment <- function(experimentId) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   baseGet(paste("experiments", experimentId, sep = "/"))
 }

--- a/R/getExperiments.R
+++ b/R/getExperiments.R
@@ -12,6 +12,6 @@
 #' # List the names of the first five experiments
 #' getExperiments(params = list("limit" = "5", "fields" = "+name"))
 #' }
-getExperiments = function(params = list()) {
+getExperiments <- function(params = list()) {
   baseGet(paste("experiments", sep = "/"), params)
 }

--- a/R/getFcsFile.R
+++ b/R/getFcsFile.R
@@ -15,10 +15,10 @@
 #' # Lookup by name
 #' getFcsFile(experimentId, byName("Sample 1.fcs"))
 #' }
-getFcsFile = function(experimentId, fcsFileId, params = list()) {
+getFcsFile <- function(experimentId, fcsFileId, params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(fcsFileId)
-  fcsFileId = lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
+  fcsFileId <- lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
   baseGet(paste("experiments", experimentId, "fcsfiles", fcsFileId, sep = "/"), params)
 }

--- a/R/getFcsFiles.R
+++ b/R/getFcsFiles.R
@@ -16,8 +16,8 @@
 #' # List the filename of the the first five files
 #' getFcsFiles(experimentId, params = list("limit" = "5", "fields" = "+filename"))
 #' }
-getFcsFiles = function(experimentId, params = list()) {
+getFcsFiles <- function(experimentId, params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   baseGet(paste("experiments", experimentId, "fcsfiles", sep = "/"), params)
 }

--- a/R/getGate.R
+++ b/R/getGate.R
@@ -9,10 +9,10 @@
 #' \dontrun{
 #' getGate(experimentId, gateId)
 #' }
-getGate = function(experimentId, gateId) {
+getGate <- function(experimentId, gateId) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(gateId)
-  gateId = lookupByName(paste("experiments", experimentId, "gates", sep = "/"), gateId)
+  gateId <- lookupByName(paste("experiments", experimentId, "gates", sep = "/"), gateId)
   baseGet(paste("experiments", experimentId, "gates", gateId, sep = "/"))
 }

--- a/R/getGates.R
+++ b/R/getGates.R
@@ -13,9 +13,9 @@
 #' # List the name and GID of the first five gates
 #' getGates(experimentId, params = list("limit" = "5", "fields" = "+name,+gid"))
 #' }
-getGates = function(experimentId, params = list()) {
+getGates <- function(experimentId, params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
-  res = baseGet(paste("experiments", experimentId, "gates", sep = "/"), params)
+  experimentId <- lookupByName("experiments", experimentId)
+  res <- baseGet(paste("experiments", experimentId, "gates", sep = "/"), params)
   res
 }

--- a/R/getPopulation.R
+++ b/R/getPopulation.R
@@ -14,10 +14,10 @@
 #' # Lookup by name
 #' getPopulation(experimentId, byName("Singlets"))
 #' }
-getPopulation = function(experimentId, populationId, params = list()) {
+getPopulation <- function(experimentId, populationId, params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(populationId)
-  populationId = lookupByName(paste("experiments", experimentId, "populations", sep = "/"), populationId)
+  populationId <- lookupByName(paste("experiments", experimentId, "populations", sep = "/"), populationId)
   baseGet(paste("experiments", experimentId, "populations", populationId, sep = "/"), params)
 }

--- a/R/getPopulations.R
+++ b/R/getPopulations.R
@@ -13,8 +13,8 @@
 #' # List the names of the first five populations
 #' getPopulations(experimentId, params = list("limit" = "5", "fields" = "+name"))
 #' }
-getPopulations = function(experimentId, params = list()) {
+getPopulations <- function(experimentId, params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   baseGet(paste("experiments", experimentId, "populations", sep = "/"), params)
 }

--- a/R/getScaleSets.R
+++ b/R/getScaleSets.R
@@ -10,8 +10,8 @@
 #' \dontrun{
 #' getScaleSets(experimentId)
 #' }
-getScaleSets = function(experimentId, params = list()) {
+getScaleSets <- function(experimentId, params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   baseGet(paste("experiments", experimentId, "scalesets", sep = "/"), params)
 }

--- a/R/setFcsFilePanel.R
+++ b/R/setFcsFilePanel.R
@@ -25,18 +25,18 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' panel = list(
+#' panel <- list(
 #'   list("index" = 1, "channel" = "FSC-A"),
 #'   list("index" = 7, "channel" = "Blue530-A", "reagent" = "CD3")
 #' )
 #' setFcsFilePanel(experimentId, fcsFileId, "Panel 1", panel)
 #' }
-setFcsFilePanel = function(experimentId, fcsFileId, panelName, panel) {
+setFcsFilePanel <- function(experimentId, fcsFileId, panelName, panel) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(fcsFileId)
-  fcsFileId = lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
-  body = jsonlite::toJSON(list(
+  fcsFileId <- lookupByName(paste("experiments", experimentId, "fcsfiles", sep = "/"), fcsFileId, "filename")
+  body <- jsonlite::toJSON(list(
     panelName = panelName,
     panel = panel
   ), null = "null", auto_unbox = TRUE)

--- a/R/setServer.R
+++ b/R/setServer.R
@@ -6,10 +6,10 @@
 #' @export
 #' @examples
 #' setServer("https://mycompany.cellengine.com")
-setServer = function(host) {
-  host = sub("/$", "", host)
+setServer <- function(host) {
+  host <- sub("/$", "", host)
   if (!grepl("^https://[0-9a-zA-Z\\.\\-]+\\.[0-9a-zA-Z\\.]+$", host, ignore.case = TRUE)) {
     stop("Argument 'host' must be a valid HTTPS url")
   }
-  pkg.env$baseURL = paste(host, "/api/v1", sep = "")
+  pkg.env$baseURL <- paste(host, "/api/v1", sep = "")
 }

--- a/R/updateExperiment.R
+++ b/R/updateExperiment.R
@@ -9,9 +9,9 @@
 #' \dontrun{
 #' updateExperiment(experimentId, list("name" = "my experiment"))
 #' }
-updateExperiment = function(experimentId, properties = list()) {
+updateExperiment <- function(experimentId, properties = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
-  body = jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
+  experimentId <- lookupByName("experiments", experimentId)
+  body <- jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
   basePatch(paste("experiments", experimentId, sep = "/"), body)
 }

--- a/R/updateGate.R
+++ b/R/updateGate.R
@@ -10,12 +10,12 @@
 #' \dontrun{
 #' updateGate(experimentId, gateId, list("name" = "new gate name"))
 #' }
-
-updateGate = function(experimentId, gateId, properties = list()) {
+#'
+updateGate <- function(experimentId, gateId, properties = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(gateId)
-  gateId = lookupByName(paste("experiments", experimentId, "gates", sep = "/"), gateId)
-  body = jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
+  gateId <- lookupByName(paste("experiments", experimentId, "gates", sep = "/"), gateId)
+  body <- jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
   basePatch(paste("experiments", experimentId, "gates", gateId, sep = "/"), body)
 }

--- a/R/updateGateFamily.R
+++ b/R/updateGateFamily.R
@@ -11,12 +11,12 @@
 #' \dontrun{
 #' updateGateFamily(experimentId, gid, list("name" = "new gate name"))
 #' }
-
-updateGateFamily = function(experimentId, gid, properties = list(), params = list()) {
+#'
+updateGateFamily <- function(experimentId, gid, properties = list(), params = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(gid)
-  body = jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
-  url = sprintf("experiments/%s/gates?gid=%s", experimentId, gid)
+  body <- jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
+  url <- sprintf("experiments/%s/gates?gid=%s", experimentId, gid)
   basePatch(url, body, params)
 }

--- a/R/updatePopulation.R
+++ b/R/updatePopulation.R
@@ -10,14 +10,14 @@
 #' \dontrun{
 #' updatePopulation(experimentId, populationId, list("name" = "new pop name"))
 #' }
-
-updatePopulation = function(experimentId,
-                            populationId,
-                            properties = list()) {
+#'
+updatePopulation <- function(experimentId,
+                             populationId,
+                             properties = list()) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
+  experimentId <- lookupByName("experiments", experimentId)
   checkDefined(populationId)
-  populationId = lookupByName(paste("experiments", experimentId, "populations", sep = "/"), populationId)
-  body = jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
+  populationId <- lookupByName(paste("experiments", experimentId, "populations", sep = "/"), populationId)
+  body <- jsonlite::toJSON(properties, null = "null", auto_unbox = TRUE)
   basePatch(paste("experiments", experimentId, "populations", populationId, sep = "/"), body)
 }

--- a/R/uploadAttachment.R
+++ b/R/uploadAttachment.R
@@ -9,11 +9,11 @@
 #' \dontrun{
 #' uploadAttachment(experimentId, "/path/to/file")
 #' }
-uploadAttachment = function(experimentId, attachmentPath) {
+uploadAttachment <- function(experimentId, attachmentPath) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
-  body = list("file" = httr::upload_file(attachmentPath))
+  experimentId <- lookupByName("experiments", experimentId)
+  body <- list("file" = httr::upload_file(attachmentPath))
   ensureBaseUrl()
-  fullURL = paste(pkg.env$baseURL, "experiments", experimentId, "attachments", sep = "/")
+  fullURL <- paste(pkg.env$baseURL, "experiments", experimentId, "attachments", sep = "/")
   handleResponse(httr::POST(fullURL, body = body, httr::user_agent(ua)))
 }

--- a/R/uploadFcsFile.R
+++ b/R/uploadFcsFile.R
@@ -9,11 +9,11 @@
 #' \dontrun{
 #' uploadFcsFile(experimentId, "/path/to/file.fcs")
 #' }
-uploadFcsFile = function(experimentId, fcsFilePath) {
+uploadFcsFile <- function(experimentId, fcsFilePath) {
   checkDefined(experimentId)
-  experimentId = lookupByName("experiments", experimentId)
-  body = list("file" = httr::upload_file(fcsFilePath))
+  experimentId <- lookupByName("experiments", experimentId)
+  body <- list("file" = httr::upload_file(fcsFilePath))
   ensureBaseUrl()
-  fullURL = paste(pkg.env$baseURL, "experiments", experimentId, "fcsfiles", sep = "/")
+  fullURL <- paste(pkg.env$baseURL, "experiments", experimentId, "fcsfiles", sep = "/")
   handleResponse(httr::POST(fullURL, body = body, httr::user_agent(ua)))
 }

--- a/R/util.R
+++ b/R/util.R
@@ -1,59 +1,60 @@
-pkg.env = new.env()
+pkg.env <- new.env() # nolint
 
 # Set your development base url in .Renviron in the package directory
-pkg.env$baseURL = Sys.getenv("CELLENGINE_API_URL", "https://cellengine.com/api/v1")
+pkg.env$baseURL <- Sys.getenv("CELLENGINE_API_URL", "https://cellengine.com/api/v1")
 
-handleResponse = function(response) {
+handleResponse <- function(response) {
   httr::warn_for_status(response)
-  content = httr::content(response, "text", encoding = "UTF-8")
+  content <- httr::content(response, "text", encoding = "UTF-8")
   return(jsonlite::fromJSON(content))
 }
 
-ua = (function (){
+ua <- (function() {
   versions <- c(
     `CellEngine API Toolkit` = "0.1.0", # TODO see if utils::packageVersion works
     libcurl = curl::curl_version()$version,
     `r-curl` = as.character(utils::packageVersion("curl")),
-    httr = as.character(utils::packageVersion("httr")))
+    httr = as.character(utils::packageVersion("httr"))
+  )
   paste0(names(versions), "/", versions, collapse = " ")
 })()
 
-ensureBaseUrl = function() {
+ensureBaseUrl <- function() {
   if (pkg.env$baseURL == "") stop("Please call setServer(host) first.")
 }
 
-baseGet = function(url, params = list()) {
+baseGet <- function(url, params = list()) {
   ensureBaseUrl()
-  fullURL = paste(pkg.env$baseURL, url, sep = "/")
+  fullURL <- paste(pkg.env$baseURL, url, sep = "/")
   handleResponse(httr::GET(fullURL, query = params, httr::user_agent(ua)))
 }
 
-basePatch = function(url, body, params = list()) {
+basePatch <- function(url, body, params = list()) {
   ensureBaseUrl()
-  fullURL = paste(pkg.env$baseURL, url, sep = "/")
+  fullURL <- paste(pkg.env$baseURL, url, sep = "/")
   handleResponse(httr::PATCH(fullURL, body = body, query = params, httr::content_type_json(), httr::user_agent(ua)))
 }
 
-basePut = function(url, body, params = list()) {
+basePut <- function(url, body, params = list()) {
   ensureBaseUrl()
-  fullURL = paste(pkg.env$baseURL, url, sep = "/")
+  fullURL <- paste(pkg.env$baseURL, url, sep = "/")
   handleResponse(httr::PUT(fullURL, body = body, query = params, httr::content_type_json(), httr::user_agent(ua)))
 }
 
-basePost = function(url, body, params = list()) {
+basePost <- function(url, body, params = list()) {
   ensureBaseUrl()
-  fullURL = paste(pkg.env$baseURL, url, sep = "/")
+  fullURL <- paste(pkg.env$baseURL, url, sep = "/")
   handleResponse(httr::POST(fullURL, body = body, query = params, httr::content_type_json(), httr::user_agent(ua)))
 }
 
-baseDelete = function(url, params = list()) {
+baseDelete <- function(url, params = list()) {
   ensureBaseUrl()
-  fullURL = paste(pkg.env$baseURL, url, sep = "/")
-  response = httr::DELETE(fullURL, query = params, httr::user_agent(ua))
+  fullURL <- paste(pkg.env$baseURL, url, sep = "/")
+  response <- httr::DELETE(fullURL, query = params, httr::user_agent(ua))
   httr::warn_for_status(response)
 }
 
-checkDefined = function(param) {
+checkDefined <- function(param) {
   if (is.null(param)) {
     stop(paste0("parameter '", deparse(substitute(param)), "' is NULL"))
   }
@@ -64,21 +65,21 @@ checkDefined = function(param) {
 #' A constant representing no compensation.
 #'
 #' @export
-UNCOMPENSATED = 0
+UNCOMPENSATED <- 0 # nolint
 
 #' File-internal compensation.
 #'
 #' A constant representing file-internal compensation.
 #'
 #' @export
-FILE_INTERNAL = -1
+FILE_INTERNAL <- -1 # nolint
 
 #' Ungated.
 #'
 #' A constant representing the ungated population.
 #'
 #' @export
-UNGATED = ""
+UNGATED <- "" # nolint
 
 #' Returns more information about the last error.
 #'
@@ -86,7 +87,7 @@ UNGATED = ""
 #' that it is retrievable using \code{getErrorInfo()}.
 #'
 #' @export
-getErrorInfo = function() {
+getErrorInfo <- function() {
   pkg.env$lastError
 }
 
@@ -113,21 +114,25 @@ getErrorInfo = function() {
 #' getGates(experimentId = byName("my experiment"))
 #' }
 #' @export
-byName = function(name) {
+byName <- function(name) {
   class(name) <- "_boxed_by_name"
   name
 }
 
-byNameHash = new.env(hash = TRUE, parent = emptyenv())
+byNameHash <- new.env(hash = TRUE, parent = emptyenv())
 
-lookupByName = function(listpath, name, prop = "name") {
-  if (class(name) != "_boxed_by_name") return(name)
-  name = unclass(name)
+lookupByName <- function(listpath, name, prop = "name") {
+  if (class(name) != "_boxed_by_name") {
+    return(name)
+  }
+  name <- unclass(name)
 
-  key = paste(listpath, name, sep="$$$")
-  if (exists(key, envir = byNameHash)) return(get(key, envir = byNameHash))
+  key <- paste(listpath, name, sep = "$$$")
+  if (exists(key, envir = byNameHash)) {
+    return(get(key, envir = byNameHash))
+  }
 
-  vals = baseGet(listpath, params = list(
+  vals <- baseGet(listpath, params = list(
     query = sprintf("eq(%s, \"%s\")", prop, name),
     limit = 2 # need >1 so we can detect ambiguous matches
   ))
@@ -138,7 +143,7 @@ lookupByName = function(listpath, name, prop = "name") {
     stop(sprintf("More than one resource with the name '%s' exists.", name))
   }
 
-  val = vals$`_id`
+  val <- vals$`_id`
   assign(key, val, envir = byNameHash)
   val
 }
@@ -156,30 +161,29 @@ lookupByName = function(listpath, name, prop = "name") {
 #'   name Name of resource to search for.
 #' @examples
 #' \dontrun{
-#' lookup = createLookup("5e1f66a06f5f3f0759b479c9")
+#' lookup <- createLookup("5e1f66a06f5f3f0759b479c9")
 #' lookup("gates", "test_gate")
 #' # or:
 #' lookup("gates")
 #' }
 #' @export
 createLookup <- function(experimentId) {
-  function(resource, name='') {
-    allowedArgs = c("gates", "populations", "fcsfiles", "compensations")
+  function(resource, name = "") {
+    allowedArgs <- c("gates", "populations", "fcsfiles", "compensations")
     if (resource %in% allowedArgs == FALSE) {
       stop(sprintf("Resource must be one of %s", paste(allowedArgs, collapse = ", ")))
     }
-    listpath = sprintf("experiments/%s/%s", experimentId, resource)
+    listpath <- sprintf("experiments/%s/%s", experimentId, resource)
 
-    if (name == '') {
-      data = baseGet(listpath)
-
+    if (name == "") {
+      data <- baseGet(listpath)
     } else {
-      args <- list(listpath=listpath, name=byName(name))
+      args <- list(listpath = listpath, name = byName(name))
       if (resource == "fcsfiles") {
         args <- c(args, list(prop = "filename"))
       }
-      id = do.call(lookupByName, args)
-      data = baseGet(sprintf("%s/%s/", listpath, id))
+      id <- do.call(lookupByName, args)
+      data <- baseGet(sprintf("%s/%s/", listpath, id))
     }
     data
   }

--- a/man/annotateFcsFile.Rd
+++ b/man/annotateFcsFile.Rd
@@ -27,7 +27,8 @@ annotations from this list before appending new ones.
 }
 \examples{
 \dontrun{
-annotations = list(list(name="annotations 1", value=1), list(name="annotation 2", value="myValue"))
+annotations <- list(list(name = "annotations 1", value = 1),
+  list(name = "annotation 2", value = "myValue"))
 annotateFcsFile(experimentId, fcsFileId, annotations)
 }
 }

--- a/man/applyScale.Rd
+++ b/man/applyScale.Rd
@@ -20,11 +20,11 @@ Applies a scale to a vector of channel values
 }
 \examples{
 \dontrun{
-applyScale(list(type='LinearScale', minimum=1, maximum=10), c(1, 2, 3, 4, 5))
+applyScale(list(type = "LinearScale", minimum = 1, maximum = 10), c(1, 2, 3, 4, 5))
 
 # Using a Scale from a CellEngine ScaleSet
-scaleSet = getScaleSets(experimentId)
-chanIdx = 5
+scaleSet <- getScaleSets(experimentId)
+chanIdx <- 5
 applyScale(scaleSet$scales[[1]][chanIdx, "scale"], c(1, 2, 3, 4, 5))
 }
 }

--- a/man/authenticate.Rd
+++ b/man/authenticate.Rd
@@ -32,7 +32,7 @@ authenticate("username", "password")
 authenticate("username", Sys.getenv("API_PASSWORD"))
 
 # If the password is omitted and you're running in RStudio or the getPass
-library is installed, a prompt will be displayed.
+# library is installed, a prompt will be displayed.
 authenticate("username")
 }
 }

--- a/man/createGates.Rd
+++ b/man/createGates.Rd
@@ -31,12 +31,18 @@ tailoring a large number of gates.
 }
 \examples{
 \dontrun{
-g1 = list(type = "RectangleGate", xChannel = "FSC-A", yChannel = "SSC-A",
-  model = list(rectangle = list(x1 = 1, x2 = 100, y1 = 1, y2 = 100)))
-g2 = list(type = "PolygonGate", xChannel = "FSC-A", yChannel = "SSC-A",
-  model = list(polygon = list(vertices = c(c(1, 2), c(30, 40), c(50, 60)))))
-g3 = list(type = "RangeGate", xChannel = "V450-480-A",
-  model = list(range = list(x1 = 1, x2 = 100, y = 0.5)))
+g1 <- list(
+  type = "RectangleGate", xChannel = "FSC-A", yChannel = "SSC-A",
+  model = list(rectangle = list(x1 = 1, x2 = 100, y1 = 1, y2 = 100))
+)
+g2 <- list(
+  type = "PolygonGate", xChannel = "FSC-A", yChannel = "SSC-A",
+  model = list(polygon = list(vertices = c(c(1, 2), c(30, 40), c(50, 60))))
+)
+g3 <- list(
+  type = "RangeGate", xChannel = "V450-480-A",
+  model = list(range = list(x1 = 1, x2 = 100, y = 0.5))
+)
 
 createGates(experimentId, c(g1, g2, g3))
 }

--- a/man/createLookup.Rd
+++ b/man/createLookup.Rd
@@ -22,7 +22,7 @@ If a name is not specified, a list of all requested resources will be returned.
 }
 \examples{
 \dontrun{
-lookup = createLookup("5e1f66a06f5f3f0759b479c9")
+lookup <- createLookup("5e1f66a06f5f3f0759b479c9")
 lookup("gates", "test_gate")
 # or:
 lookup("gates")

--- a/man/createPopulation.Rd
+++ b/man/createPopulation.Rd
@@ -34,7 +34,7 @@ Creates a population.
 }
 \examples{
 \dontrun{
-gid1 = "59262d84b1a1fc1193f12b0e"
+gid1 <- "59262d84b1a1fc1193f12b0e"
 createPopulation(experimentId, "Singlets", list(`$and` = c(gid1)), gid1)
 }
 }

--- a/man/deleteGates.Rd
+++ b/man/deleteGates.Rd
@@ -36,4 +36,5 @@ for the experimentId).
 deleteGate(experimentId, gid = gateFamilyID)
 deleteGate(experimentId, gateId = gateID)
 }
+
 }

--- a/man/downloadAttachment.Rd
+++ b/man/downloadAttachment.Rd
@@ -28,7 +28,7 @@ Downloads an attachment and returns it as a binary blob or saves it to disk.
 \examples{
 \dontrun{
 # Returns the attachment as a binary blob:
-attachment = downloadAttachment(experimentId, attachmentId)
+attachment <- downloadAttachment(experimentId, attachmentId)
 # Parse it as text:
 readBin(attachment, character())
 

--- a/man/downloadFcsFiles.Rd
+++ b/man/downloadFcsFiles.Rd
@@ -74,7 +74,7 @@ Downloads multiple files bundled into a ZIP archive.
 # Download all FCS files in the experiment
 downloadFcsFiles(experimentId, "fcs", "archive.zip", overwrite = T)
 # Download specific FCS files
-fcsFileIds=c("5d2f8b4b21fd0676fb3a6a72", "5d2f8b4b21fd0676fb3a6a74")
-downloadFcsFiles(experimentId, "fcs", "archive.zip", fcsFileIds=fcsFileIds)
+fcsFileIds <- c("5d2f8b4b21fd0676fb3a6a72", "5d2f8b4b21fd0676fb3a6a74")
+downloadFcsFiles(experimentId, "fcs", "archive.zip", fcsFileIds = fcsFileIds)
 }
 }

--- a/man/getEvents.Rd
+++ b/man/getEvents.Rd
@@ -76,7 +76,7 @@ getEvents(experimentId, fcsFileId, destination = "/path/to/output.fcs")
 getEvents(experimentId, fcsFileId, destination = "/path/to/output.tsv", format = "TSV", headerQ = T)
 
 # Subsamples and gates to only contain events in the specified population:
-subsampling = list(preSubsampleN = 5000, seed = 1.5)
+subsampling <- list(preSubsampleN = 5000, seed = 1.5)
 getEvents(experimentId, fcsFileId, populationId, subsampling = subsampling)
 }
 }

--- a/man/getStatistics.Rd
+++ b/man/getStatistics.Rd
@@ -95,29 +95,35 @@ all non-control FCS files.
 \examples{
 \dontrun{
 # Quick syntax, using population names and file names instead of IDs:
-fcsFiles = c("file1.fcs")
-channels = c("SSC-A", "YG780/60-A")
-statistics = c("median", "mean", "quantile", "percent")
-populations = c("Leukocytes")
-stats = getStatistics(experimentId, fcsFiles = fcsFiles, channels = channels,
+fcsFiles <- c("file1.fcs")
+channels <- c("SSC-A", "YG780/60-A")
+statistics <- c("median", "mean", "quantile", "percent")
+populations <- c("Leukocytes")
+stats <- getStatistics(experimentId,
+  fcsFiles = fcsFiles, channels = channels,
   statistics = statistics, populations = populations, q = 0.95,
-  compensationId = cellengine::FILE_INTERNAL)
+  compensationId = cellengine::FILE_INTERNAL
+)
 # Returns a data.frame of statistics, including the file annotations.
 # Because percentOf is not specified, "percent" will be percent of parent.
 
 # Explicit syntax, using IDs instead of population and file names, and
 # specifying a scaleSetId:
-fcsFileIds = c("9ab5c6d7a8cf24a5c4f9a6c2")
-statistics = c("percent")
-populationIds = c("9ab5c6d7a8cf24a5c4f9face")
-scaleSetId = "9ab5c6d7a8cf24a5c4f9fdde"
-stats = getStatistics(experimentId, fcsFileIds = fcsFileIds,
+fcsFileIds <- c("9ab5c6d7a8cf24a5c4f9a6c2")
+statistics <- c("percent")
+populationIds <- c("9ab5c6d7a8cf24a5c4f9face")
+scaleSetId <- "9ab5c6d7a8cf24a5c4f9fdde"
+stats <- getStatistics(experimentId,
+  fcsFileIds = fcsFileIds,
   statistics = statistics, populationIds = populationIds,
-  compensationId = cellengine::UNCOMPENSATED, scaleSetId = scaleSetId)
+  compensationId = cellengine::UNCOMPENSATED, scaleSetId = scaleSetId
+)
 
 # Percent of ungated:
-getStatistics(experimentId, fcsFileIds = fcsFileIds, statistics = statistics,
+getStatistics(experimentId,
+  fcsFileIds = fcsFileIds, statistics = statistics,
   populationIds = populationIds, compensationId = cellengine::UNCOMPENSATED,
-  percentOf = cellengine::UNGATED)
+  percentOf = cellengine::UNGATED
+)
 }
 }

--- a/man/setFcsFilePanel.Rd
+++ b/man/setFcsFilePanel.Rd
@@ -37,7 +37,7 @@ The \code{panelName} property is used to group files by panel.
 }
 \examples{
 \dontrun{
-panel = list(
+panel <- list(
   list("index" = 1, "channel" = "FSC-A"),
   list("index" = 7, "channel" = "Blue530-A", "reagent" = "CD3")
 )

--- a/man/updateGate.Rd
+++ b/man/updateGate.Rd
@@ -20,4 +20,5 @@ Updates a gate.
 \dontrun{
 updateGate(experimentId, gateId, list("name" = "new gate name"))
 }
+
 }

--- a/man/updateGateFamily.Rd
+++ b/man/updateGateFamily.Rd
@@ -22,4 +22,5 @@ Updates a gate family.
 \dontrun{
 updateGateFamily(experimentId, gid, list("name" = "new gate name"))
 }
+
 }

--- a/man/updatePopulation.Rd
+++ b/man/updatePopulation.Rd
@@ -20,4 +20,5 @@ Updates a population.
 \dontrun{
 updatePopulation(experimentId, populationId, list("name" = "new pop name"))
 }
+
 }

--- a/tests/testthat/test-annotateFcsFile.R
+++ b/tests/testthat/test-annotateFcsFile.R
@@ -4,13 +4,13 @@ test_that("Correct HTTP request is made", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "PATCH")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc")
-      body = rawToChar(req$options$postfields)
-      expect_equal(body, '{"annotations":[{"name":"annotation 1","value":"myvalue"},{"name":"annotation 2","value":2.12}]}')
-      response = httptest::fake_response(
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc") # nolint
+      body <- rawToChar(req$options$postfields)
+      expect_equal(body, '{"annotations":[{"name":"annotation 1","value":"myvalue"},{"name":"annotation 2","value":2.12}]}') # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"filename":"Specimen_001_A2_A02_MeOHperm(DL350neg).fcs","gridId":"593f3ae211005114b1bf03e2","hasFileInternalComp":true,"panelName":"Panel 1","__v":0,"_id":"591a3b441d725115208a6fdc","spillString":"8,Blue530-A,Vio450-A,Vio605-A,UV450-A,Red670-A,YG582-A,YG610-A,YG780-A,1,0,0,0,0,0,0,0,0,1,0.019999998552000027,0.055000000000000014,0,0,0,0,0.003000000000000001,0.012999999058800013,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1","crc32c":"76633d32","eventCount":164684,"md5":"4a0ded33c1f55c6ff52c90dbe3c4894d","experimentId":"591a3b441d725115208a6fda","panel":[{"index":1,"channel":"FSC-A"},{"index":7,"reagent":"CD3","channel":"Blue530-A"}],"annotations":[{"type":"any","value":"myvalue","name":"annotation 1"},{"type":"any","value":2.12,"name":"annotation 2"}]}',
+        content = '{"filename":"Specimen_001_A2_A02_MeOHperm(DL350neg).fcs","gridId":"593f3ae211005114b1bf03e2","hasFileInternalComp":true,"panelName":"Panel 1","__v":0,"_id":"591a3b441d725115208a6fdc","spillString":"8,Blue530-A,Vio450-A,Vio605-A,UV450-A,Red670-A,YG582-A,YG610-A,YG780-A,1,0,0,0,0,0,0,0,0,1,0.019999998552000027,0.055000000000000014,0,0,0,0,0.003000000000000001,0.012999999058800013,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1","crc32c":"76633d32","eventCount":164684,"md5":"4a0ded33c1f55c6ff52c90dbe3c4894d","experimentId":"591a3b441d725115208a6fda","panel":[{"index":1,"channel":"FSC-A"},{"index":7,"reagent":"CD3","channel":"Blue530-A"}],"annotations":[{"type":"any","value":"myvalue","name":"annotation 1"},{"type":"any","value":2.12,"name":"annotation 2"}]}', # nolint
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -18,17 +18,17 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      annos = list(
+      annos <- list(
         list(
           name = "annotation 1",
           value = "myvalue"
-          ),
+        ),
         list(
           name = "annotation 2",
           value = 2.12
-          )
+        )
       )
-      resp = annotateFcsFile("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc", annos)
+      resp <- annotateFcsFile("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc", annos)
     }
   )
 })

--- a/tests/testthat/test-applyScale.R
+++ b/tests/testthat/test-applyScale.R
@@ -1,58 +1,58 @@
 context("applyScale")
 
 test_that("applies linear scale to list", {
-  data = c(10.0, 7.0, 1.2, 9.0, 40.0)
+  data <- c(10.0, 7.0, 1.2, 9.0, 40.0)
   scale <- list(
     minimum = 1,
     maximum = 10,
     type = "LinearScale"
   )
 
-  result = applyScale(scale, data, clamp_q=FALSE)
+  result <- applyScale(scale, data, clamp_q = FALSE)
   expect_equal(data, result)
 })
 
 test_that("clamps linear scale", {
-  data = c(10.0, 7.0, 1.2, 9.0, 40.0)
+  data <- c(10.0, 7.0, 1.2, 9.0, 40.0)
   scale <- list(
     minimum = 5,
     maximum = 10,
     type = "LinearScale"
   )
 
-  result = applyScale(scale, data, clamp_q=TRUE)
-  expected = c(10.0, 7.0, 5.0, 9.0, 10.0)
+  result <- applyScale(scale, data, clamp_q = TRUE)
+  expected <- c(10.0, 7.0, 5.0, 9.0, 10.0)
   expect_equal(expected, result)
 })
 
 test_that("applies log scale", {
-  data = c(10.0, -1, 7.0, 1.2, 9.0, 40.0)
+  data <- c(10.0, -1, 7.0, 1.2, 9.0, 40.0)
   scale <- list(
     minimum = 2,
     maximum = 10,
     type = "LogScale"
   )
 
-  result = applyScale(scale, data, clamp_q=FALSE)
-  expected = c(1.0, 0, 0.845098, 0.07918125, 0.9542425, 1.60206)
-  expect_equal(expected, result, tolerance=0.001)
+  result <- applyScale(scale, data, clamp_q = FALSE)
+  expected <- c(1.0, 0, 0.845098, 0.07918125, 0.9542425, 1.60206)
+  expect_equal(expected, result, tolerance = 0.001)
 })
 
 test_that("applies clamped log scale", {
-  data = c(10.0, 7.0, 1.2, 9.0, 40.0)
+  data <- c(10.0, 7.0, 1.2, 9.0, 40.0)
   scale <- list(
     minimum = 2,
     maximum = 10,
     type = "LogScale"
   )
 
-  result = applyScale(scale, data, clamp_q=TRUE)
-  expected = c(1.0, 0.845098, 0.30103, 0.9542425, 1.0)
-  expect_equal(expected, result, tolerance=0.001)
+  result <- applyScale(scale, data, clamp_q = TRUE)
+  expected <- c(1.0, 0.845098, 0.30103, 0.9542425, 1.0)
+  expect_equal(expected, result, tolerance = 0.001)
 })
 
 test_that("applies arcsinh scale", {
-  data = c(-250, -20, -2, -0.01, 0, 0.2, 0.5, 1)
+  data <- c(-250, -20, -2, -0.01, 0, 0.2, 0.5, 1)
   scale <- list(
     minimum = -200,
     maximum = 5000,
@@ -60,13 +60,13 @@ test_that("applies arcsinh scale", {
     type = "ArcSinhScale"
   )
 
-  result = applyScale(scale, data, clamp_q=FALSE)
-  expected = c(-4.60527, -2.094713, -0.3900353, -0.001999999, 0, 0.03998934, 0.09983408, 0.1986901)
-  expect_equal(expected, result, tolerance=0.001)
+  result <- applyScale(scale, data, clamp_q = FALSE)
+  expected <- c(-4.60527, -2.094713, -0.3900353, -0.001999999, 0, 0.03998934, 0.09983408, 0.1986901)
+  expect_equal(expected, result, tolerance = 0.001)
 })
 
 test_that("applies clamped arcsinh scale", {
-  data = c(-250, -20, -2, -0.01, 0, 0.2, 0.5, 1)
+  data <- c(-250, -20, -2, -0.01, 0, 0.2, 0.5, 1)
   scale <- list(
     minimum = -200,
     maximum = 5000,
@@ -74,7 +74,7 @@ test_that("applies clamped arcsinh scale", {
     type = "ArcSinhScale"
   )
 
-  result = applyScale(scale, data, clamp_q=TRUE)
-  expected = c(-4.382183, -2.094713, -0.3900353, -0.001999999, 0, 0.03998934, 0.09983408, 0.1986901)
-  expect_equal(expected, result, tolerance=0.001)
+  result <- applyScale(scale, data, clamp_q = TRUE)
+  expected <- c(-4.382183, -2.094713, -0.3900353, -0.001999999, 0, 0.03998934, 0.09983408, 0.1986901)
+  expect_equal(expected, result, tolerance = 0.001)
 })

--- a/tests/testthat/test-authenticate.R
+++ b/tests/testthat/test-authenticate.R
@@ -5,12 +5,12 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/signin")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       expect_equal(body, '{"username":"user1","password":"p@ssword"}')
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"token":"s:abcdefgh.ijklmnop/pqr","userId":"592799bd14ac0ad59699cb77","admin":false,"flags":{}}',
+        content = '{"token":"s:abcdefgh.ijklmnop/pqr","userId":"592799bd14ac0ad59699cb77","admin":false,"flags":{}}',
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -28,12 +28,12 @@ test_that("Correct HTTP request is made with OTP", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/signin")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       expect_equal(body, '{"username":"user1","password":"p@ssword","otp":"012345"}')
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"token":"s:abcdefgh.ijklmnop/pqr","userId":"592799bd14ac0ad59699cb77","admin":false,"flags":{}}',
+        content = '{"token":"s:abcdefgh.ijklmnop/pqr","userId":"592799bd14ac0ad59699cb77","admin":false,"flags":{}}',
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )

--- a/tests/testthat/test-createEllipseGate.R
+++ b/tests/testthat/test-createEllipseGate.R
@@ -5,14 +5,14 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid value
-      expect_match(body, '{"model":{"locked":false,"ellipse":{"center":\\[106299.536082474,85580.3298969073\\],"angle":0.703952917888142,"major":166096.63099403,"minor":102655.519773813},"label":\\[106299.536082474,85580.3298969073\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"EllipseGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"ellipse":{"center":\\[106299.536082474,85580.3298969073\\],"angle":0.703952917888142,"major":166096.63099403,"minor":102655.519773813},"label":\\[106299.536082474,85580.3298969073\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"EllipseGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[106299.536082474,85580.3298969073],"ellipse":{"angle":0.7039529178881421,"major":166096.6309940297,"minor":102655.51977381333,"center":[106299.53608247427,85580.32989690728]},"locked":false},"gid":"59289ff2461f1fd925fca4ff","xChannel":"FSC-A","type":"EllipseGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"59289ff59989cc7704ada3c0","tailoredPerFile":false,"id":"59289ff59989cc7704ada3c0"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[106299.536082474,85580.3298969073],"ellipse":{"angle":0.7039529178881421,"major":166096.6309940297,"minor":102655.51977381333,"center":[106299.53608247427,85580.32989690728]},"locked":false},"gid":"59289ff2461f1fd925fca4ff","xChannel":"FSC-A","type":"EllipseGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"59289ff59989cc7704ada3c0","tailoredPerFile":false,"id":"59289ff59989cc7704ada3c0"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,16 +20,17 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createEllipseGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+      resp <- createEllipseGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
         106299.536082474, 85580.3298969073, 0.7039529178881421, 166096.6309940297, 102655.51977381333,
-        createPopulation = FALSE)
-      resp = resp$gate
+        createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "59289ff59989cc7704ada3c0") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$yChannel, "FSC-W")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$label, c(106299.536082474,85580.3298969073))
+      expect_equal(resp$model$label, c(106299.536082474, 85580.3298969073))
       expect_equal(resp$model$ellipse$center, c(106299.53608247427, 85580.32989690728))
       expect_equal(resp$model$ellipse$angle, 0.7039529178881421)
       expect_equal(resp$model$ellipse$major, 166096.6309940297)
@@ -48,14 +49,14 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid value
-      expect_match(body, '{"model":{"locked":false,"ellipse":{"center":\\[106299.536082474,85580.3298969073\\],"angle":0.703952917888142,"major":166096.63099403,"minor":102655.519773813},"label":\\[106299.536082474,85580.3298969073\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"EllipseGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"59289ff2461f1fd925fca4aa"}', perl = TRUE)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"ellipse":{"center":\\[106299.536082474,85580.3298969073\\],"angle":0.703952917888142,"major":166096.63099403,"minor":102655.519773813},"label":\\[106299.536082474,85580.3298969073\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"EllipseGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"59289ff2461f1fd925fca4aa"}', perl = TRUE) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[106299.536082474,85580.3298969073],"ellipse":{"angle":0.7039529178881421,"major":166096.6309940297,"minor":102655.51977381333,"center":[106299.53608247427,85580.32989690728]},"locked":false},"gid":"59289ff2461f1fd925fca4ff","xChannel":"FSC-A","type":"EllipseGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"59289ff59989cc7704ada3c0","tailoredPerFile":true,"id":"59289ff59989cc7704ada3c0","fcsFileId":"59289ff2461f1fd925fca4aa"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[106299.536082474,85580.3298969073],"ellipse":{"angle":0.7039529178881421,"major":166096.6309940297,"minor":102655.51977381333,"center":[106299.53608247427,85580.32989690728]},"locked":false},"gid":"59289ff2461f1fd925fca4ff","xChannel":"FSC-A","type":"EllipseGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"59289ff59989cc7704ada3c0","tailoredPerFile":true,"id":"59289ff59989cc7704ada3c0","fcsFileId":"59289ff2461f1fd925fca4aa"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -63,16 +64,17 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     },
     {
       setServer("https://my.server.com")
-      resp = createEllipseGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+      resp <- createEllipseGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
         106299.536082474, 85580.3298969073, 0.7039529178881421, 166096.6309940297, 102655.51977381333,
-        tailoredPerFile = TRUE, fcsFileId = "59289ff2461f1fd925fca4aa", createPopulation = FALSE)
-      resp = resp$gate
+        tailoredPerFile = TRUE, fcsFileId = "59289ff2461f1fd925fca4aa", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "59289ff59989cc7704ada3c0") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$yChannel, "FSC-W")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$label, c(106299.536082474,85580.3298969073))
+      expect_equal(resp$model$label, c(106299.536082474, 85580.3298969073))
       expect_equal(resp$model$ellipse$center, c(106299.53608247427, 85580.32989690728))
       expect_equal(resp$model$ellipse$angle, 0.7039529178881421)
       expect_equal(resp$model$ellipse$major, 166096.6309940297)
@@ -91,13 +93,17 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
-              {"_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"}
+              {
+                "_id":"591a3b5f1d725115208a7087",
+                "experimentId":"591a3b441d725115208a6fda",
+                "name":"singlets","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,
+                "terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"}
             ]',
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
@@ -105,14 +111,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
+          body <- rawToChar(req$options$postfields)
           # Literal except for the gid value
-          expect_match(body, '{"model":{"locked":false,"ellipse":{"center":\\[106299.536082474,85580.3298969073\\],"angle":0.703952917888142,"major":166096.63099403,"minor":102655.519773813},"label":\\[106299.536082474,85580.3298969073\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"EllipseGate","parentPopulationId":"591a3b5f1d725115208a7087","name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE)
-          response = httptest::fake_response(
+          expect_match(body, '{"model":{"locked":false,"ellipse":{"center":\\[106299.536082474,85580.3298969073\\],"angle":0.703952917888142,"major":166096.63099403,"minor":102655.519773813},"label":\\[106299.536082474,85580.3298969073\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"EllipseGate","parentPopulationId":"591a3b5f1d725115208a7087","name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE) # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
             # Fixed GID, not the one passed in
-            content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[106299.536082474,85580.3298969073],"ellipse":{"angle":0.7039529178881421,"major":166096.6309940297,"minor":102655.51977381333,"center":[106299.53608247427,85580.32989690728]},"locked":false},"gid":"59289ff2461f1fd925fca4ff","xChannel":"FSC-A","type":"EllipseGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"59289ff59989cc7704ada3c0","tailoredPerFile":false,"id":"59289ff59989cc7704ada3c0"}',
+            content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[106299.536082474,85580.3298969073],"ellipse":{"angle":0.7039529178881421,"major":166096.6309940297,"minor":102655.51977381333,"center":[106299.53608247427,85580.32989690728]},"locked":false},"gid":"59289ff2461f1fd925fca4ff","xChannel":"FSC-A","type":"EllipseGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"59289ff59989cc7704ada3c0","tailoredPerFile":false,"id":"59289ff59989cc7704ada3c0"}', # nolint
             status_code = 201,
             headers = list(`Content-Type` = "application/json")
           )
@@ -122,20 +128,20 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
           stop(sprintf("Unexpected request URL: %s", req$url))
         }
       )
-
     },
     {
       setServer("https://my.server.com")
-      resp = createEllipseGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+      resp <- createEllipseGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
         106299.536082474, 85580.3298969073, 0.7039529178881421, 166096.6309940297, 102655.51977381333,
-        parentPopulation = "singlets", createPopulation = FALSE)
-      resp = resp$gate
+        parentPopulation = "singlets", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "59289ff59989cc7704ada3c0") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$yChannel, "FSC-W")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$label, c(106299.536082474,85580.3298969073))
+      expect_equal(resp$model$label, c(106299.536082474, 85580.3298969073))
       expect_equal(resp$model$ellipse$center, c(106299.53608247427, 85580.32989690728))
       expect_equal(resp$model$ellipse$angle, 0.7039529178881421)
       expect_equal(resp$model$ellipse$major, 166096.6309940297)

--- a/tests/testthat/test-createExperiment.R
+++ b/tests/testthat/test-createExperiment.R
@@ -5,12 +5,12 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       expect_equal(body, '{"name":"my experiment"}')
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"__v":0,"_id":"591a3b441d725115208a6fda","name":"my experiment"}',
+        content = '{"__v":0,"_id":"591a3b441d725115208a6fda","name":"my experiment"}',
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -18,7 +18,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createExperiment(list("name" = "my experiment"))
+      resp <- createExperiment(list("name" = "my experiment"))
       expect_equal(resp$`_id`, "591a3b441d725115208a6fda")
       expect_equal(resp$name, "my experiment")
     }

--- a/tests/testthat/test-createLookup.R
+++ b/tests/testthat/test-createLookup.R
@@ -2,23 +2,23 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/593b44a7ff5925084dd96ed1/gates?query=eq%28name%2C%20%22my%20gate%22%29&limit=2" = {
+        "https://my.server.com/api/v1/experiments/593b44a7ff5925084dd96ed1/gates?query=eq%28name%2C%20%22my%20gate%22%29&limit=2" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content='[{"name":"Tiny plate","created":"2017-06-10T01:00:23.638Z","__v":0,"_id":"593b44a7ff5925084dd96ed1","public":false,"uploader":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"permissions":{},"primaryResearcher":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"updated":"2017-06-10T01:00:25.632Z"}]',
+            content = '[{"name":"Tiny plate","created":"2017-06-10T01:00:23.638Z","__v":0,"_id":"593b44a7ff5925084dd96ed1","public":false,"uploader":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"permissions":{},"primaryResearcher":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"updated":"2017-06-10T01:00:25.632Z"}]', # nolint
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
         },
         "https://my.server.com/api/v1/experiments/593b44a7ff5925084dd96ed1/gates/593b44a7ff5925084dd96ed1/" = {
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             # Fixed GID, not the one passed in
-            content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+            content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -28,12 +28,11 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
           stop(sprintf("Unexpected request URL: %s", req$url))
         }
       )
-
     },
     {
       setServer("https://my.server.com")
-      lookup = createLookup("593b44a7ff5925084dd96ed1")
-      resp = lookup("gates", "my gate")
+      lookup <- createLookup("593b44a7ff5925084dd96ed1")
+      resp <- lookup("gates", "my gate")
       expect_equal(resp$name, "my gate")
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4")

--- a/tests/testthat/test-createPolygonGate.R
+++ b/tests/testthat/test-createPolygonGate.R
@@ -5,14 +5,14 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid value
-      expect_match(body, '{"model":{"locked":false,"polygon":{"vertices":\\[\\[37836.07,971.51\\],\\[1588732.12,154.646\\],\\[8139.405,664.78\\],\\[9441.949,781.32\\]\\]},"label":\\[411037.386,643.064\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"PolygonGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"polygon":{"vertices":\\[\\[37836.07,971.51\\],\\[1588732.12,154.646\\],\\[8139.405,664.78\\],\\[9441.949,781.32\\]\\]},"label":\\[411037.386,643.064\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"PolygonGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,10 +20,11 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createPolygonGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
-        list(c(37836.07, 971.51), c(1588732.12,154.646),  c(8139.405, 664.78), c(9441.949,  781.32)),
-        createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createPolygonGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+        list(c(37836.07, 971.51), c(1588732.12, 154.646), c(8139.405, 664.78), c(9441.949, 781.32)),
+        createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
@@ -50,14 +51,14 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid value
-      expect_match(body, '{"model":{"locked":false,"polygon":{"vertices":\\[\\[37836.07,971.51\\],\\[1588732.12,154.646\\],\\[8139.405,664.78\\],\\[9441.949,781.32\\]\\]},"label":\\[411037.386,643.064\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"PolygonGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl = TRUE)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"polygon":{"vertices":\\[\\[37836.07,971.51\\],\\[1588732.12,154.646\\],\\[8139.405,664.78\\],\\[9441.949,781.32\\]\\]},"label":\\[411037.386,643.064\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"PolygonGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl = TRUE) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -65,10 +66,11 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     },
     {
       setServer("https://my.server.com")
-      resp = createPolygonGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
-        list(c(37836.07, 971.51), c(1588732.12,154.646),  c(8139.405, 664.78), c(9441.949,  781.32)),
-        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createPolygonGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+        list(c(37836.07, 971.51), c(1588732.12, 154.646), c(8139.405, 664.78), c(9441.949, 781.32)),
+        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
@@ -95,13 +97,18 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
-              {"_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"}
+              {
+                "_id":"591a3b5f1d725115208a7087",
+                "experimentId":"591a3b441d725115208a6fda","name":"singlets",
+                "gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}",
+                "parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,
+                "id":"591a3b5f1d725115208a7087"}
             ]',
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
@@ -109,14 +116,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
+          body <- rawToChar(req$options$postfields)
           # Literal except for the gid value
-          expect_match(body, '{"model":{"locked":false,"polygon":{"vertices":\\[\\[37836.07,971.51\\],\\[1588732.12,154.646\\],\\[8139.405,664.78\\],\\[9441.949,781.32\\]\\]},"label":\\[411037.386,643.064\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"PolygonGate","parentPopulationId":"591a3b5f1d725115208a7087","name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE)
-          response = httptest::fake_response(
+          expect_match(body, '{"model":{"locked":false,"polygon":{"vertices":\\[\\[37836.07,971.51\\],\\[1588732.12,154.646\\],\\[8139.405,664.78\\],\\[9441.949,781.32\\]\\]},"label":\\[411037.386,643.064\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"PolygonGate","parentPopulationId":"591a3b5f1d725115208a7087","name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE) # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
             # Fixed GID, not the one passed in
-            content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+            content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"polygon":{"vertices":[[37836.07,971.51],[1588732.12,154.646],[8139.405,664.78],[9441.949,781.32]]},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"PolygonGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
             status_code = 201,
             headers = list(`Content-Type` = "application/json")
           )
@@ -126,14 +133,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
           stop(sprintf("Unexpected request URL: %s", req$url))
         }
       )
-
     },
     {
       setServer("https://my.server.com")
-      resp = createPolygonGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
-        list(c(37836.07, 971.51), c(1588732.12,154.646),  c(8139.405, 664.78), c(9441.949,  781.32)),
-        parentPopulation = "singlets", createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createPolygonGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+        list(c(37836.07, 971.51), c(1588732.12, 154.646), c(8139.405, 664.78), c(9441.949, 781.32)),
+        parentPopulation = "singlets", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")

--- a/tests/testthat/test-createPopulation.R
+++ b/tests/testthat/test-createPopulation.R
@@ -5,12 +5,12 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations")
-      body = rawToChar(req$options$postfields)
-      expect_equal(body, "{\"name\":\"Singlets\",\"gates\":\"{\\\"$and\\\":[\\\"59262d84b1a1fc1193f12b0e\\\"]}\",\"terminalGateGid\":\"59262d84b1a1fc1193f12b0e\",\"parentId\":null}")
-      response = httptest::fake_response(
+      body <- rawToChar(req$options$postfields)
+      expect_equal(body, "{\"name\":\"Singlets\",\"gates\":\"{\\\"$and\\\":[\\\"59262d84b1a1fc1193f12b0e\\\"]}\",\"terminalGateGid\":\"59262d84b1a1fc1193f12b0e\",\"parentId\":null}") # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content="{\"_id\":\"59263d09b1a1fc1193f12b0f\",\"name\":\"Singlets\",\"gates\":\"{\\\"$and\\\":[\\\"59262d84b1a1fc1193f12b0e\\\"]}\",\"terminalGateGid\":\"59262d84b1a1fc1193f12b0e\",\"parentId\":null}",
+        content = "{\"_id\":\"59263d09b1a1fc1193f12b0f\",\"name\":\"Singlets\",\"gates\":\"{\\\"$and\\\":[\\\"59262d84b1a1fc1193f12b0e\\\"]}\",\"terminalGateGid\":\"59262d84b1a1fc1193f12b0e\",\"parentId\":null}", # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -18,7 +18,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createPopulation("591a3b441d725115208a6fda", "Singlets", list(`$and` = c("59262d84b1a1fc1193f12b0e")), "59262d84b1a1fc1193f12b0e")
+      resp <- createPopulation("591a3b441d725115208a6fda", "Singlets", list(`$and` = c("59262d84b1a1fc1193f12b0e")), "59262d84b1a1fc1193f12b0e") # nolint
       expect_equal(resp$`_id`, "59263d09b1a1fc1193f12b0f") # assigned server-side
       expect_equal(resp$parentId, NULL) # default assigned client-side
       expect_equal(resp$name, "Singlets")

--- a/tests/testthat/test-createQuadrantGate.R
+++ b/tests/testthat/test-createQuadrantGate.R
@@ -5,14 +5,14 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid values
-      expect_match(body, '{"model":{"locked":false,"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":\\[1.5707963267949,3.14159265358979,4.71238898038469,0\\]},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[196608,196608\\],\\[0.75,196608\\],\\[0.75,0.75\\],\\[196608,0.75\\]\\],"skewable":false},"xChannel":"FSC-A","yChannel":"FSC-W","names":\\["my gate \\(UR\\)","my gate \\(UL\\)","my gate \\(LL\\)","my gate \\(LR\\)"\\],"type":"QuadrantGate\","parentPopulationId":null,"gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl=T)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":\\[1.5707963267949,3.14159265358979,4.71238898038469,0\\]},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[196608,196608\\],\\[0.75,196608\\],\\[0.75,0.75\\],\\[196608,0.75\\]\\],"skewable":false},"xChannel":"FSC-A","yChannel":"FSC-W","names":\\["my gate \\(UR\\)","my gate \\(UL\\)","my gate \\(LL\\)","my gate \\(LR\\)"\\],"type":"QuadrantGate\","parentPopulationId":null,"gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = T) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[196608.00, 0.75], [0.75, 196608.00], [196608.00, 196608.00], [0.75, 0.75]],"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":[1.5707963267949,3.14159265358979,4.71238898038469,0]},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4","5d30960a417e4bc767a428a5","5d30960a417e4bc767a428a6"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","yChannel":"FSC-W","type":"QuadrantGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[196608.00, 0.75], [0.75, 196608.00], [196608.00, 196608.00], [0.75, 0.75]],"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":[1.5707963267949,3.14159265358979,4.71238898038469,0]},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4","5d30960a417e4bc767a428a5","5d30960a417e4bc767a428a6"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","yChannel":"FSC-W","type":"QuadrantGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,24 +20,25 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createQuadrantGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
-        118010.39175257733, 182870.51546391752, labels = list(c(196608.00, 196608.00), c(0.75, 196608.00), c(0.75, 0.75), c(196608.00, 0.75)), createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createQuadrantGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+        118010.39175257733, 182870.51546391752,
+        labels = list(c(196608.00, 196608.00), c(0.75, 196608.00), c(0.75, 0.75), c(196608.00, 0.75)), createPopulation = FALSE # nolint
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$yChannel, "FSC-W")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$labels, matrix(c(c(196608.00,0.75), c(0.75, 196608.00), c(196608.00, 196608.00), c(0.75, 0.75)), byrow=T, ncol=2))
+      expect_equal(resp$model$labels, matrix(c(c(196608.00, 0.75), c(0.75, 196608.00), c(196608.00, 196608.00), c(0.75, 0.75)), byrow = T, ncol = 2)) # nolint
       expect_equal(resp$model$quadrant$x, 118010.391752577)
       expect_equal(resp$model$quadrant$y, 182870.515463918)
       expect_equal(resp$model$locked, FALSE)
-      expect_equal(resp$model$gids, c("5d30960a417e4bc767a428a3", "5d30960a417e4bc767a428a4", "5d30960a417e4bc767a428a5", "5d30960a417e4bc767a428a6"))
+      expect_equal(resp$model$gids, c("5d30960a417e4bc767a428a3", "5d30960a417e4bc767a428a4", "5d30960a417e4bc767a428a5", "5d30960a417e4bc767a428a6")) # nolint
       expect_equal(resp$gid, "592640a5a6a1d6256ec9b08a")
       expect_equal(resp$parentPopulationId, NULL) # default assigned client-side
       expect_equal(resp$type, "QuadrantGate")
       expect_equal(resp$tailoredPerFile, FALSE)
-
     }
   )
 })
@@ -47,14 +48,14 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid values
-      expect_match(body, '{"model":{"locked":false,"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":\\[1.5707963267949,3.14159265358979,4.71238898038469,0\\]},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[196608,196608\\],\\[0.75,196608\\],\\[0.75,0.75\\],\\[196608,0.75\\]\\],"skewable":false},"xChannel":"FSC-A","yChannel":"FSC-W","names":\\["my gate \\(UR\\)","my gate \\(UL\\)","my gate \\(LL\\)","my gate \\(LR\\)"\\],"type":"QuadrantGate\","parentPopulationId":null,"gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl=T)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":\\[1.5707963267949,3.14159265358979,4.71238898038469,0\\]},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[196608,196608\\],\\[0.75,196608\\],\\[0.75,0.75\\],\\[196608,0.75\\]\\],"skewable":false},"xChannel":"FSC-A","yChannel":"FSC-W","names":\\["my gate \\(UR\\)","my gate \\(UL\\)","my gate \\(LL\\)","my gate \\(LR\\)"\\],"type":"QuadrantGate\","parentPopulationId":null,"gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl = T) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[196608.00, 0.75], [0.75, 196608.00], [196608.00, 196608.00], [0.75, 0.75]],"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":[1.5707963267949,3.14159265358979,4.71238898038469,0]},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4","5d30960a417e4bc767a428a5","5d30960a417e4bc767a428a6"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","yChannel":"FSC-W","type":"QuadrantGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[196608.00, 0.75], [0.75, 196608.00], [196608.00, 196608.00], [0.75, 0.75]],"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":[1.5707963267949,3.14159265358979,4.71238898038469,0]},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4","5d30960a417e4bc767a428a5","5d30960a417e4bc767a428a6"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","yChannel":"FSC-W","type":"QuadrantGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -62,20 +63,33 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     },
     {
       setServer("https://my.server.com")
-      resp = createQuadrantGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
-        118010.39175257733, 182870.51546391752, labels = list(c(196608.00, 196608.00), c(0.75, 196608.00), c(0.75, 0.75), c(196608.00, 0.75)),
-        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createQuadrantGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+        118010.39175257733, 182870.51546391752,
+        labels = list(c(196608.00, 196608.00), c(0.75, 196608.00), c(0.75, 0.75), c(196608.00, 0.75)),
+        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$yChannel, "FSC-W")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$labels, matrix(c(c(196608.00,0.75), c(0.75, 196608.00), c(196608.00, 196608.00), c(0.75, 0.75)), byrow=T, ncol=2))
+      expect_equal(
+        resp$model$labels,
+        matrix(c(c(196608.00, 0.75), c(0.75, 196608.00), c(196608.00, 196608.00), c(0.75, 0.75)), byrow = T, ncol = 2)
+      )
       expect_equal(resp$model$quadrant$x, 118010.391752577)
       expect_equal(resp$model$quadrant$y, 182870.515463918)
       expect_equal(resp$model$locked, FALSE)
-      expect_equal(resp$model$gids, c("5d30960a417e4bc767a428a3", "5d30960a417e4bc767a428a4", "5d30960a417e4bc767a428a5", "5d30960a417e4bc767a428a6"))
+      expect_equal(
+        resp$model$gids,
+        c(
+          "5d30960a417e4bc767a428a3",
+          "5d30960a417e4bc767a428a4",
+          "5d30960a417e4bc767a428a5",
+          "5d30960a417e4bc767a428a6"
+        )
+      )
       expect_equal(resp$gid, "592640a5a6a1d6256ec9b08a")
       expect_equal(resp$parentPopulationId, NULL) # default assigned client-side
       expect_equal(resp$type, "QuadrantGate")
@@ -90,13 +104,17 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
-              {"_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"}
+              {
+                "_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets",
+                "gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,
+                "terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"
+              }
             ]',
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
@@ -104,14 +122,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
+          body <- rawToChar(req$options$postfields)
           # Literal except for the gid values
-          expect_match(body, '{"model":{"locked":false,"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":\\[1.5707963267949,3.14159265358979,4.71238898038469,0\\]},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[196608,196608\\],\\[0.75,196608\\],\\[0.75,0.75\\],\\[196608,0.75\\]\\],"skewable":false},"xChannel":"FSC-A","yChannel":"FSC-W","names":\\["my gate \\(UR\\)","my gate \\(UL\\)","my gate \\(LL\\)","my gate \\(LR\\)"\\],"type":"QuadrantGate\","parentPopulationId":"591a3b5f1d725115208a7087","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl=T)
-          response = httptest::fake_response(
+          expect_match(body, '{"model":{"locked":false,"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":\\[1.5707963267949,3.14159265358979,4.71238898038469,0\\]},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[196608,196608\\],\\[0.75,196608\\],\\[0.75,0.75\\],\\[196608,0.75\\]\\],"skewable":false},"xChannel":"FSC-A","yChannel":"FSC-W","names":\\["my gate \\(UR\\)","my gate \\(UL\\)","my gate \\(LL\\)","my gate \\(LR\\)"\\],"type":"QuadrantGate\","parentPopulationId":"591a3b5f1d725115208a7087","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = T) # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
             # Fixed GID, not the one passed in
-            content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[196608.00, 0.75], [0.75, 196608.00], [196608.00, 196608.00], [0.75, 0.75]],"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":[1.5707963267949,3.14159265358979,4.71238898038469,0]},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4","5d30960a417e4bc767a428a5","5d30960a417e4bc767a428a6"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","yChannel":"FSC-W","type":"QuadrantGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}',
+            content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[196608.00, 0.75], [0.75, 196608.00], [196608.00, 196608.00], [0.75, 0.75]],"quadrant":{"x":118010.391752577,"y":182870.515463918,"angles":[1.5707963267949,3.14159265358979,4.71238898038469,0]},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4","5d30960a417e4bc767a428a5","5d30960a417e4bc767a428a6"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","yChannel":"FSC-W","type":"QuadrantGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}', # nolint
             status_code = 201,
             headers = list(`Content-Type` = "application/json")
           )
@@ -121,24 +139,36 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
           stop(sprintf("Unexpected request URL: %s", req$url))
         }
       )
-
     },
     {
       setServer("https://my.server.com")
-      resp = createQuadrantGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
-        118010.39175257733, 182870.51546391752, labels = list(c(196608.00, 196608.00), c(0.75, 196608.00), c(0.75, 0.75), c(196608.00, 0.75)),
-        parentPopulation = "singlets", createPopulation = FALSE, tailoredPerFile = FALSE)
-      resp = resp$gate
+      resp <- createQuadrantGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+        118010.39175257733, 182870.51546391752,
+        labels = list(c(196608.00, 196608.00), c(0.75, 196608.00), c(0.75, 0.75), c(196608.00, 0.75)),
+        parentPopulation = "singlets", createPopulation = FALSE, tailoredPerFile = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$yChannel, "FSC-W")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$labels, matrix(c(c(196608.00,0.75), c(0.75, 196608.00), c(196608.00, 196608.00), c(0.75, 0.75)), byrow=T, ncol=2))
+      expect_equal(
+        resp$model$labels,
+        matrix(c(c(196608.00, 0.75), c(0.75, 196608.00), c(196608.00, 196608.00), c(0.75, 0.75)), byrow = T, ncol = 2)
+      )
       expect_equal(resp$model$quadrant$x, 118010.391752577)
       expect_equal(resp$model$quadrant$y, 182870.515463918)
       expect_equal(resp$model$locked, FALSE)
-      expect_equal(resp$model$gids, c("5d30960a417e4bc767a428a3", "5d30960a417e4bc767a428a4", "5d30960a417e4bc767a428a5", "5d30960a417e4bc767a428a6"))
+      expect_equal(
+        resp$model$gids,
+        c(
+          "5d30960a417e4bc767a428a3",
+          "5d30960a417e4bc767a428a4",
+          "5d30960a417e4bc767a428a5",
+          "5d30960a417e4bc767a428a6"
+        )
+      )
       expect_equal(resp$gid, "592640a5a6a1d6256ec9b08a")
       expect_equal(resp$parentPopulationId, "591a3b5f1d725115208a7087")
       expect_equal(resp$type, "QuadrantGate")
@@ -146,5 +176,3 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
     }
   )
 })
-
-

--- a/tests/testthat/test-createRangeGate.R
+++ b/tests/testthat/test-createRangeGate.R
@@ -5,14 +5,14 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid value
-      expect_match(body, '{"model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":\\[178.95,0.5\\]},"xChannel":"FSC-A","type":"RangeGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":\\[178.95,0.5\\]},"xChannel":"FSC-A","type":"RangeGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":[178.95,0.5]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RangeGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":[178.95,0.5]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RangeGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,9 +20,11 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createRangeGate("591a3b441d725115208a6fda", "FSC-A", "my gate",
-        123.4, 234.5, createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createRangeGate("591a3b441d725115208a6fda", "FSC-A", "my gate",
+        123.4, 234.5,
+        createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
@@ -45,14 +47,14 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid value
-      expect_match(body, '{"model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":\\[178.95,0.5\\]},"xChannel":"FSC-A","type":"RangeGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl = TRUE)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":\\[178.95,0.5\\]},"xChannel":"FSC-A","type":"RangeGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl = TRUE) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":[178.95,0.5]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RangeGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":[178.95,0.5]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RangeGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -60,9 +62,10 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     },
     {
       setServer("https://my.server.com")
-      resp = createRangeGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 123.4, 234.5,
-        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createRangeGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 123.4, 234.5,
+        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
@@ -85,13 +88,17 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
-              {"_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"}
+              {
+                "_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets",
+                "gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,
+                "terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"
+              }
             ]',
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
@@ -99,14 +106,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
+          body <- rawToChar(req$options$postfields)
           # Literal except for the gid value
-          expect_match(body, '{"model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":\\[178.95,0.5\\]},"xChannel":"FSC-A","type":"RangeGate","parentPopulationId":"591a3b5f1d725115208a7087","name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE)
-          response = httptest::fake_response(
+          expect_match(body, '{"model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":\\[178.95,0.5\\]},"xChannel":"FSC-A","type":"RangeGate","parentPopulationId":"591a3b5f1d725115208a7087","name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE) # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
             # Fixed GID, not the one passed in
-            content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":[178.95,0.5]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RangeGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+            content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"range":{"x1":123.4,"x2":234.5,"y":0.5},"label":[178.95,0.5]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RangeGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
             status_code = 201,
             headers = list(`Content-Type` = "application/json")
           )
@@ -116,13 +123,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
           stop(sprintf("Unexpected request URL: %s", req$url))
         }
       )
-
     },
     {
       setServer("https://my.server.com")
-      resp = createRangeGate("591a3b441d725115208a6fda", "FSC-A", "my gate",
-        123.4, 234.5, parentPopulation = "singlets", createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createRangeGate("591a3b441d725115208a6fda", "FSC-A", "my gate",
+        123.4, 234.5,
+        parentPopulation = "singlets", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")

--- a/tests/testthat/test-createRectangleGate.R
+++ b/tests/testthat/test-createRectangleGate.R
@@ -5,14 +5,14 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid value
-      expect_match(body, '{"model":{"locked":false,"rectangle":{"x1":118010.391752577,"x2":182870.515463918,"y1":190978.030927835,"y2":214399.742268041},"label":\\[150440.453608247,202688.886597938\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"RectangleGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"rectangle":{"x1":118010.391752577,"x2":182870.515463918,"y1":190978.030927835,"y2":214399.742268041},"label":\\[150440.453608247,202688.886597938\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"RectangleGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"rectangle":{"y2":214399.74226804124,"x2":182870.51546391752,"y1":190978.03092783503,"x1":118010.39175257733},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RectangleGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"rectangle":{"y2":214399.74226804124,"x2":182870.51546391752,"y1":190978.03092783503,"x1":118010.39175257733},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RectangleGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,10 +20,11 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createRectangleGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+      resp <- createRectangleGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
         118010.39175257733, 182870.51546391752, 190978.03092783503, 214399.74226804124,
-        createPopulation = FALSE)
-      resp = resp$gate
+        createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
@@ -48,14 +49,14 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid value
-      expect_match(body, '{"model":{"locked":false,"rectangle":{"x1":118010.391752577,"x2":182870.515463918,"y1":190978.030927835,"y2":214399.742268041},"label":\\[150440.453608247,202688.886597938\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"RectangleGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl = TRUE)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"rectangle":{"x1":118010.391752577,"x2":182870.515463918,"y1":190978.030927835,"y2":214399.742268041},"label":\\[150440.453608247,202688.886597938\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"RectangleGate","parentPopulationId":null,"name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl = TRUE) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"rectangle":{"y2":214399.74226804124,"x2":182870.51546391752,"y1":190978.03092783503,"x1":118010.39175257733},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RectangleGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"rectangle":{"y2":214399.74226804124,"x2":182870.51546391752,"y1":190978.03092783503,"x1":118010.39175257733},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RectangleGate","name":"my gate","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -63,10 +64,11 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     },
     {
       setServer("https://my.server.com")
-      resp = createRectangleGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+      resp <- createRectangleGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
         118010.39175257733, 182870.51546391752, 190978.03092783503, 214399.74226804124,
-        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE)
-      resp = resp$gate
+        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
@@ -91,13 +93,17 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
-              {"_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"}
+              {
+                "_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets",
+                "gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,
+                "terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"
+              }
             ]',
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
@@ -105,14 +111,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
+          body <- rawToChar(req$options$postfields)
           # Literal except for the gid value
-          expect_match(body, '{"model":{"locked":false,"rectangle":{"x1":118010.391752577,"x2":182870.515463918,"y1":190978.030927835,"y2":214399.742268041},"label":\\[150440.453608247,202688.886597938\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"RectangleGate","parentPopulationId":"591a3b5f1d725115208a7087","name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE)
-          response = httptest::fake_response(
+          expect_match(body, '{"model":{"locked":false,"rectangle":{"x1":118010.391752577,"x2":182870.515463918,"y1":190978.030927835,"y2":214399.742268041},"label":\\[150440.453608247,202688.886597938\\]},"xChannel":"FSC-A","yChannel":"FSC-W","type":"RectangleGate","parentPopulationId":"591a3b5f1d725115208a7087","name":"my gate","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = TRUE) # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
             # Fixed GID, not the one passed in
-            content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"rectangle":{"y2":214399.74226804124,"x2":182870.51546391752,"y1":190978.03092783503,"x1":118010.39175257733},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RectangleGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+            content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"rectangle":{"y2":214399.74226804124,"x2":182870.51546391752,"y1":190978.03092783503,"x1":118010.39175257733},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RectangleGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
             status_code = 201,
             headers = list(`Content-Type` = "application/json")
           )
@@ -122,14 +128,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
           stop(sprintf("Unexpected request URL: %s", req$url))
         }
       )
-
     },
     {
       setServer("https://my.server.com")
-      resp = createRectangleGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
+      resp <- createRectangleGate("591a3b441d725115208a6fda", "FSC-A", "FSC-W", "my gate",
         118010.39175257733, 182870.51546391752, 190978.03092783503, 214399.74226804124,
-        parentPopulation = "singlets", createPopulation = FALSE)
-      resp = resp$gate
+        parentPopulation = "singlets", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")

--- a/tests/testthat/test-createSplitGate.R
+++ b/tests/testthat/test-createSplitGate.R
@@ -5,14 +5,14 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid values
-      expect_match(body, '{"model":{"locked":false,"split":{"x":144000,"y":0.5},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[26215.4,0.95\\],\\[235929.6,0.95\\]\\]},"xChannel":"FSC-A","names":\\["my gate \\(L\\)","my gate \\(R\\)"\\],"type":"SplitGate","parentPopulationId":null,"gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl=T)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"split":{"x":144000,"y":0.5},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[26215.4,0.95\\],\\[235929.6,0.95\\]\\]},"xChannel":"FSC-A","names":\\["my gate \\(L\\)","my gate \\(R\\)"\\],"type":"SplitGate","parentPopulationId":null,"gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = T) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[26215.4,0.95], [235929.6, 0.95]],"split":{"x":144000,"y":0.5},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"SplitGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[26215.4,0.95], [235929.6, 0.95]],"split":{"x":144000,"y":0.5},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"SplitGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,13 +20,16 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, labels = list(c(26215.4,0.95), c(235929.6, 0.95)), createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createSplitGate(
+        "591a3b441d725115208a6fda", "FSC-A", "my gate", 144000,
+        labels = list(c(26215.4, 0.95), c(235929.6, 0.95)), createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$labels, matrix(c(c(26215.4,0.95), c(235929.6, 0.95)), byrow=T, ncol=2))
+      expect_equal(resp$model$labels, matrix(c(c(26215.4, 0.95), c(235929.6, 0.95)), byrow = T, ncol = 2))
       expect_equal(resp$model$split$x, 144000)
       expect_equal(resp$model$split$y, 0.5)
       expect_equal(resp$model$locked, FALSE)
@@ -35,7 +38,6 @@ test_that("Correct HTTP request is made", {
       expect_equal(resp$parentPopulationId, NULL) # default assigned client-side
       expect_equal(resp$type, "SplitGate")
       expect_equal(resp$tailoredPerFile, FALSE)
-
     }
   )
 })
@@ -45,14 +47,14 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       # Literal except for the gid values
-      expect_match(body, '{"model":{"locked":false,"split":{"x":144000,"y":0.5},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[26215.4,0.95\\],\\[235929.6,0.95\\]\\]},"xChannel":"FSC-A","names":\\["my gate \\(L\\)","my gate \\(R\\)"\\],"type":"SplitGate","parentPopulationId":null,"gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl=T)
-      response = httptest::fake_response(
+      expect_match(body, '{"model":{"locked":false,"split":{"x":144000,"y":0.5},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[26215.4,0.95\\],\\[235929.6,0.95\\]\\]},"xChannel":"FSC-A","names":\\["my gate \\(L\\)","my gate \\(R\\)"\\],"type":"SplitGate","parentPopulationId":null,"gid":"[0-9A-Za-z]{24}","tailoredPerFile":true,"fcsFileId":"591a3b441d725115208a6fdf"}', perl = T) # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
         # Fixed GID, not the one passed in
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[26215.4,0.95], [235929.6, 0.95]],"split":{"x":144000,"y":0.5},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"SplitGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}',
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[26215.4,0.95], [235929.6, 0.95]],"split":{"x":144000,"y":0.5},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"SplitGate","name":"my gate","parentPopulationId":null,"_id":"592640aa298f1480900e10e4","tailoredPerFile":true,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -60,14 +62,16 @@ test_that("Correct HTTP request is made, fcsFileId specified", {
     },
     {
       setServer("https://my.server.com")
-      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, labels = list(c(26215.4,0.95), c(235929.6, 0.95)),
-                             tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE)
-      resp = resp$gate
+      resp <- createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000,
+        labels = list(c(26215.4, 0.95), c(235929.6, 0.95)),
+        tailoredPerFile = TRUE, fcsFileId = "591a3b441d725115208a6fdf", createPopulation = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$labels, matrix(c(c(26215.4,0.95), c(235929.6, 0.95)), byrow=T, ncol=2))
+      expect_equal(resp$model$labels, matrix(c(c(26215.4, 0.95), c(235929.6, 0.95)), byrow = T, ncol = 2))
       expect_equal(resp$model$split$x, 144000)
       expect_equal(resp$model$split$y, 0.5)
       expect_equal(resp$model$locked, FALSE)
@@ -86,13 +90,17 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22singlets%22%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
-              {"_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"}
+              {
+                "_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"singlets",
+                "gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,
+                "terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"
+              }
             ]',
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
@@ -100,14 +108,14 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
+          body <- rawToChar(req$options$postfields)
           # Literal except for the gid values
-        expect_match(body, '{"model":{"locked":false,"split":{"x":144000,"y":0.5},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[26215.4,0.95\\],\\[235929.6,0.95\\]\\]},"xChannel":"FSC-A","names":\\["my gate \\(L\\)","my gate \\(R\\)"\\],"type":"SplitGate","parentPopulationId":"591a3b5f1d725115208a7087","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl=T)
-          response = httptest::fake_response(
+          expect_match(body, '{"model":{"locked":false,"split":{"x":144000,"y":0.5},"gids":\\["[0-9A-Za-z]{24}","[0-9A-Za-z]{24}"\\],"labels":\\[\\[26215.4,0.95\\],\\[235929.6,0.95\\]\\]},"xChannel":"FSC-A","names":\\["my gate \\(L\\)","my gate \\(R\\)"\\],"type":"SplitGate","parentPopulationId":"591a3b5f1d725115208a7087","gid":"[0-9A-Za-z]{24}","tailoredPerFile":false}', perl = T) # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
             # Fixed GID, not the one passed in
-            content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[26215.4,0.95], [235929.6, 0.95]],"split":{"x":144000,"y":0.5},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"SplitGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}',
+            content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"locked":false,"labels":[[26215.4,0.95], [235929.6, 0.95]],"split":{"x":144000,"y":0.5},"gids":["5d30960a417e4bc767a428a3","5d30960a417e4bc767a428a4"]},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"SplitGate","name":"my gate","parentPopulationId":"591a3b5f1d725115208a7087","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4","fcsFileId":"591a3b441d725115208a6fdf"}', # nolint
             status_code = 201,
             headers = list(`Content-Type` = "application/json")
           )
@@ -117,18 +125,19 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
           stop(sprintf("Unexpected request URL: %s", req$url))
         }
       )
-
     },
     {
       setServer("https://my.server.com")
-      resp = createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000, labels = list(c(26215.4,0.95), c(235929.6, 0.95)),
-                             parentPopulation = "singlets", createPopulation = FALSE, tailoredPerFile = FALSE)
-      resp = resp$gate
+      resp <- createSplitGate("591a3b441d725115208a6fda", "FSC-A", "my gate", 144000,
+        labels = list(c(26215.4, 0.95), c(235929.6, 0.95)),
+        parentPopulation = "singlets", createPopulation = FALSE, tailoredPerFile = FALSE
+      )
+      resp <- resp$gate
       expect_equal(resp$experimentId, "591a3b441d725115208a6fda")
       expect_equal(resp$`_id`, "592640aa298f1480900e10e4") # assigned server-side
       expect_equal(resp$xChannel, "FSC-A")
       expect_equal(resp$name, "my gate")
-      expect_equal(resp$model$labels, matrix(c(c(26215.4,0.95), c(235929.6, 0.95)), byrow=T, ncol=2))
+      expect_equal(resp$model$labels, matrix(c(c(26215.4, 0.95), c(235929.6, 0.95)), byrow = T, ncol = 2))
       expect_equal(resp$model$split$x, 144000)
       expect_equal(resp$model$split$y, 0.5)
       expect_equal(resp$model$locked, FALSE)
@@ -140,5 +149,3 @@ test_that("Correct HTTP request is made, parentPopulation specified", {
     }
   )
 })
-
-

--- a/tests/testthat/test-deleteExperiment.R
+++ b/tests/testthat/test-deleteExperiment.R
@@ -5,10 +5,10 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "DELETE")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='',
+        content = "",
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -16,7 +16,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = deleteExperiment("591a3b441d725115208a6fda")
+      resp <- deleteExperiment("591a3b441d725115208a6fda")
     }
   )
 })

--- a/tests/testthat/test-deleteFcsFile.R
+++ b/tests/testthat/test-deleteFcsFile.R
@@ -4,11 +4,11 @@ test_that("Correct HTTP request is made", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "DELETE")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc")
-      response = httptest::fake_response(
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc") # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='',
+        content = "",
         status_code = 204,
         headers = list(`Content-Type` = "application/json")
       )
@@ -16,7 +16,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = deleteFcsFile("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc")
+      resp <- deleteFcsFile("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc")
     }
   )
 })

--- a/tests/testthat/test-deleteGates.R
+++ b/tests/testthat/test-deleteGates.R
@@ -4,11 +4,11 @@ test_that("Correct HTTP request is made", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "DELETE")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates?gid=591a3b441d725115208a6fdc")
-      response = httptest::fake_response(
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates?gid=591a3b441d725115208a6fdc") # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='',
+        content = "",
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -16,7 +16,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = deleteGates("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc")
+      resp <- deleteGates("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc")
     }
   )
 })

--- a/tests/testthat/test-deletePopulationAuto.R
+++ b/tests/testthat/test-deletePopulationAuto.R
@@ -4,11 +4,11 @@ test_that("Correct HTTP request is made", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "DELETE")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations/591a3b441d725115208a6fdc?deleteBranch=true")
-      response = httptest::fake_response(
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations/591a3b441d725115208a6fdc?deleteBranch=true") # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='',
+        content = "",
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -16,7 +16,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = deletePopulationAuto("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc")
+      resp <- deletePopulationAuto("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc")
     }
   )
 })

--- a/tests/testthat/test-downloadAttachment.R
+++ b/tests/testthat/test-downloadAttachment.R
@@ -4,11 +4,11 @@ test_that("makes expected HTTP request", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "GET")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/attachments/591a3b441d725115208a6fde")
-      response = httptest::fake_response(
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/attachments/591a3b441d725115208a6fde") # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content="text",
+        content = "text",
         status_code = 200,
         headers = list(`Content-Type` = "text/plain; charset=utf-8")
       )
@@ -16,7 +16,7 @@ test_that("makes expected HTTP request", {
     },
     {
       setServer("https://my.server.com")
-      resp = downloadAttachment("591a3b441d725115208a6fda", "591a3b441d725115208a6fde")
+      resp <- downloadAttachment("591a3b441d725115208a6fda", "591a3b441d725115208a6fde")
     }
   )
 })

--- a/tests/testthat/test-gateUtil.R
+++ b/tests/testthat/test-gateUtil.R
@@ -3,13 +3,17 @@ context("parsePopulationArgs")
 test_that("returns the ID of a single matching population", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22name%22%29")
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22name%22%29") # nolint
       expect_equal(req$method, "GET")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
         content = '[
-          {"_id":"591a3b5f1d725115208a7088","experimentId":"591a3b441d725115208a6fda","name":"name","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33b\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7088"}
+          {
+            "_id":"591a3b5f1d725115208a7088","experimentId":"591a3b441d725115208a6fda","name":"name",
+            "gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33b\\"]}","parentId":null,
+            "terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7088"
+          }
         ]',
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
@@ -18,30 +22,36 @@ test_that("returns the ID of a single matching population", {
     },
     {
       setServer("https://my.server.com")
-      result = parsePopulationArgs(NULL, "name", "591a3b441d725115208a6fda")
+      result <- parsePopulationArgs(NULL, "name", "591a3b441d725115208a6fda")
       expect_equal(result, "591a3b5f1d725115208a7088")
     }
   )
 })
 
 test_that("passes through the parentPopulationId if provided", {
-  {
-    result = parsePopulationArgs("591a3b5f1d725115208a7088", NULL, "591a3b441d725115208a6fda")
-    expect_equal(result, "591a3b5f1d725115208a7088")
-  }
+  result <- parsePopulationArgs("591a3b5f1d725115208a7088", NULL, "591a3b441d725115208a6fda")
+  expect_equal(result, "591a3b5f1d725115208a7088")
 })
 
 test_that("throws an error if multiple populations match", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22name%22%29")
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22name%22%29") # nolint
       expect_equal(req$method, "GET")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
         content = '[
-          {"_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"name","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"},
-          {"_id":"591a3b5f1d725115208a7088","experimentId":"591a3b441d725115208a6fda","name":"name","gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33b\\"]}","parentId":null,"terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7088"}
+          {
+            "_id":"591a3b5f1d725115208a7087","experimentId":"591a3b441d725115208a6fda","name":"name",
+            "gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33a\\"]}","parentId":null,
+            "terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7087"
+          },
+          {
+            "_id":"591a3b5f1d725115208a7088","experimentId":"591a3b441d725115208a6fda","name":"name",
+            "gates":"{\\"$and\\":[\\"591a3b5961a8a2302d15a33b\\"]}","parentId":null,
+            "terminalGateGid":"591a3b5961a8a2302d15a33a","__v":0,"id":"591a3b5f1d725115208a7088"
+          }
         ]',
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
@@ -56,25 +66,27 @@ test_that("throws an error if multiple populations match", {
 })
 
 test_that("throws an error if both parentPopulationId and parentPopulation are provided", {
-  {
-    setServer("https://my.server.com")
-    expect_error(
-      parsePopulationArgs("591a3b441d725115208a6fdc", "name", "591a3b441d725115208a6fda"),
-      "Please specify only one"
-    )
-  }
+  setServer("https://my.server.com")
+  expect_error(
+    parsePopulationArgs(
+      "591a3b441d725115208a6fdc",
+      "name",
+      "591a3b441d725115208a6fda"
+    ),
+    "Please specify only one"
+  )
 })
 
 test_that("throws an error if no populations match", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22name%22%29")
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?query=eq%28name%2C%20%22name%22%29") # nolint
       expect_equal(req$method, "GET")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content = '[
-        ]',
+        content = "[
+        ]",
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -92,9 +104,9 @@ context("parseFcsFileArgs")
 test_that("assigns the ID of a single matching fcsFile", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?query=eq%28filename%2C%20%22name%22%29&fields=%2B_id")
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?query=eq%28filename%2C%20%22name%22%29&fields=%2B_id") # nolint
       expect_equal(req$method, "GET")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
         content = '[
@@ -107,25 +119,23 @@ test_that("assigns the ID of a single matching fcsFile", {
     },
     {
       setServer("https://my.server.com")
-      result = parseFcsFileArgs(list(), TRUE, NULL, "name", "591a3b441d725115208a6fda")
+      result <- parseFcsFileArgs(list(), TRUE, NULL, "name", "591a3b441d725115208a6fda")
       expect_equal(result$fcsFileId, jsonlite::unbox("591a3b5f1d725115208a7088"))
     }
   )
 })
 
 test_that("passes through the fcsFileId if provided", {
-  {
-    result = parseFcsFileArgs(list(), TRUE, "591a3b5f1d725115208a7088", NULL, "591a3b441d725115208a6fda")
-    expect_equal(result$fcsFileId, jsonlite::unbox("591a3b5f1d725115208a7088"))
-  }
+  result <- parseFcsFileArgs(list(), TRUE, "591a3b5f1d725115208a7088", NULL, "591a3b441d725115208a6fda")
+  expect_equal(result$fcsFileId, jsonlite::unbox("591a3b5f1d725115208a7088"))
 })
 
 test_that("throws an error if multiple fcsFiles match", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?query=eq%28filename%2C%20%22name%22%29&fields=%2B_id")
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?query=eq%28filename%2C%20%22name%22%29&fields=%2B_id") # nolint
       expect_equal(req$method, "GET")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
         content = '[
@@ -144,41 +154,29 @@ test_that("throws an error if multiple fcsFiles match", {
   )
 })
 
-test_that("throws an error if both fcsFileId and fcsFile are provided", {
-  {
-    setServer("https://my.server.com")
-    expect_error(
-      parseFcsFileArgs(list(), TRUE, "591a3b441d725115208a6fdc", "name", "591a3b441d725115208a6fda"),
-      "Please specify only one"
-    )
-  }
-})
+test_that("throws an error if both fcsFileId and fcsFile are provided", {{ setServer("https://my.server.com")
+  expect_error(
+    parseFcsFileArgs(list(), TRUE, "591a3b441d725115208a6fdc", "name", "591a3b441d725115208a6fda"),
+    "Please specify only one"
+  ) }})
 
-test_that("doesn't assign fcsFileId if not tailored", {
-  {
-    setServer("https://my.server.com")
-    result = parseFcsFileArgs(list(), FALSE, NULL, "name", "591a3b441d725115208a6fda")
-    expect_null(result$fcsFileId)
-  }
-})
+test_that("doesn't assign fcsFileId if not tailored", {{ setServer("https://my.server.com")
+  result <- parseFcsFileArgs(list(), FALSE, NULL, "name", "591a3b441d725115208a6fda")
+  expect_null(result$fcsFileId) }})
 
-test_that("doesn't assign fcsFileId if global tailored gate", {
-  {
-    setServer("https://my.server.com")
-    result = parseFcsFileArgs(list(), TRUE, NULL, NULL, "591a3b441d725115208a6fda")
-    expect_null(result$fcsFileId)
-  }
-})
+test_that("doesn't assign fcsFileId if global tailored gate", {{ setServer("https://my.server.com")
+  result <- parseFcsFileArgs(list(), TRUE, NULL, NULL, "591a3b441d725115208a6fda")
+  expect_null(result$fcsFileId) }})
 
 test_that("throws an error if no fcsFiles match", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?query=eq%28filename%2C%20%22name%22%29&fields=%2B_id")
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?query=eq%28filename%2C%20%22name%22%29&fields=%2B_id") # nolint
       expect_equal(req$method, "GET")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content = '[]',
+        content = "[]",
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )

--- a/tests/testthat/test-getEvents.R
+++ b/tests/testthat/test-getEvents.R
@@ -4,11 +4,11 @@ test_that("makes expected HTTP request", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "GET")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc.FCS?compensatedQ=FALSE&headers=FALSE")
-      response = httptest::fake_response(
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc.FCS?compensatedQ=FALSE&headers=FALSE") # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='FCS3.1   00000000000000000000000000000000',
+        content = "FCS3.1   00000000000000000000000000000000",
         status_code = 200,
         headers = list(`Content-Type` = "application/vnd.isac.fcs")
       )
@@ -16,7 +16,7 @@ test_that("makes expected HTTP request", {
     },
     {
       setServer("https://my.server.com")
-      resp = getEvents("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc")
+      resp <- getEvents("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc")
     }
   )
 })
@@ -25,11 +25,11 @@ test_that("makes expected HTTP request with subsampling", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "GET")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc.FCS?compensatedQ=FALSE&headers=FALSE&preSubsampleN=50&seed=2.25")
-      response = httptest::fake_response(
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc.FCS?compensatedQ=FALSE&headers=FALSE&preSubsampleN=50&seed=2.25") # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='FCS3.1   00000000000000000000000000000000',
+        content = "FCS3.1   00000000000000000000000000000000",
         status_code = 200,
         headers = list(`Content-Type` = "application/vnd.isac.fcs")
       )
@@ -37,7 +37,11 @@ test_that("makes expected HTTP request with subsampling", {
     },
     {
       setServer("https://my.server.com")
-      resp = getEvents("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc", subsampling = list(preSubsampleN = 50, seed = 2.25))
+      resp <- getEvents(
+        "591a3b441d725115208a6fda",
+        "591a3b441d725115208a6fdc",
+        subsampling = list(preSubsampleN = 50, seed = 2.25)
+      )
     }
   )
 })

--- a/tests/testthat/test-getExperiment.R
+++ b/tests/testthat/test-getExperiment.R
@@ -5,10 +5,10 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "GET")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"name":"Tiny plate","created":"2017-06-10T01:00:23.638Z","__v":0,"_id":"593b44a7ff5925084dd96ed1","public":false,"uploader":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"permissions":{},"primaryResearcher":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"updated":"2017-06-10T01:00:25.632Z"}',
+        content = '{"name":"Tiny plate","created":"2017-06-10T01:00:23.638Z","__v":0,"_id":"593b44a7ff5925084dd96ed1","public":false,"uploader":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"permissions":{},"primaryResearcher":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"updated":"2017-06-10T01:00:25.632Z"}', # nolint
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -16,7 +16,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = getExperiment("591a3b441d725115208a6fda")
+      resp <- getExperiment("591a3b441d725115208a6fda")
       expect_equal(resp$name, "Tiny plate")
     }
   )

--- a/tests/testthat/test-getStatistics.R
+++ b/tests/testthat/test-getStatistics.R
@@ -1,22 +1,20 @@
 context("getStatistics")
 
-test_that("throws an error if both fcsFileIds and fcsFiles is specified", {
-  {
-    expect_error(
-      getStatistics("eid", statistics = c(), compensationId = 0,
-        fcsFileIds = c("a"), fcsFiles = c("b")),
-      "only one of 'fcsFiles"
-    )
-  }
-})
+test_that("throws an error if both fcsFileIds and fcsFiles is specified", {{ expect_error(
+  getStatistics("eid",
+    statistics = c(), compensationId = 0,
+    fcsFileIds = c("a"), fcsFiles = c("b")
+  ),
+  "only one of 'fcsFiles"
+) }})
 
 test_that("looks up fcsFiles by name; unambiguous match", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -36,7 +34,14 @@ test_that("looks up fcsFiles by name; unambiguous match", {
       setServer("https://my.server.com")
       # Specify both populationIds and populations so the call dies after the lookup
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", populationIds = 'some ID', populations = 'some population', statistics = c(), compensationId = 0, fcsFiles = c("filename1.fcs")),
+        getStatistics(
+          "591a3b441d725115208a6fda",
+          populationIds = "some ID",
+          populations = "some population",
+          statistics = c(),
+          compensationId = 0,
+          fcsFiles = c("filename1.fcs")
+        ),
         "Please specify only one of 'populations' or 'populationIds'."
       )
     }
@@ -47,9 +52,9 @@ test_that("looks up fcsFiles by name; errors with ambiguous results", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -80,9 +85,9 @@ test_that("looks up fcsFiles by name; errors with too few results", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%2C%22filename2.fcs%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%2C%22filename2.fcs%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -101,8 +106,10 @@ test_that("looks up fcsFiles by name; errors with too few results", {
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c(), compensationId = 0,
-          fcsFiles = c("filename1.fcs", "filename2.fcs")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c(), compensationId = 0,
+          fcsFiles = c("filename1.fcs", "filename2.fcs")
+        ),
         "1 file\\(s\\) were not found"
       )
     }
@@ -113,12 +120,12 @@ test_that("looks up fcsFiles by name; errors with zero results", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%2C%22filename2.fcs%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%2C%22filename2.fcs%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[]',
+            content = "[]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -132,8 +139,10 @@ test_that("looks up fcsFiles by name; errors with zero results", {
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c(), compensationId = 0,
-          fcsFiles = c("filename1.fcs", "filename2.fcs")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c(), compensationId = 0,
+          fcsFiles = c("filename1.fcs", "filename2.fcs")
+        ),
         "2 file\\(s\\) were not found"
       )
     }
@@ -144,9 +153,9 @@ test_that("looks up fcsFiles by name; errors with too few and ambiguous results"
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%2C%22filename2.fcs%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles?fields=%2Bfilename&query=in%28filename%2C%20%5B%22filename1.fcs%22%2C%22filename2.fcs%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -166,31 +175,31 @@ test_that("looks up fcsFiles by name; errors with too few and ambiguous results"
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c(), compensationId = 0,
-          fcsFiles = c("filename1.fcs", "filename2.fcs")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c(), compensationId = 0,
+          fcsFiles = c("filename1.fcs", "filename2.fcs")
+        ),
         "1 file\\(s\\) were not found"
       )
     }
   )
 })
 
-test_that("throws an error if both populationIds and populations is specified", {
-  {
-    expect_error(
-      getStatistics("eid", statistics = c(), compensationId = 0, fcsFileIds = c("a"),
-        populationIds = c("a"), populations = c("b")),
-      "only one"
-    )
-  }
-})
+test_that("throws an error if both populationIds and populations is specified", {{ expect_error(
+  getStatistics("eid",
+    statistics = c(), compensationId = 0, fcsFileIds = c("a"),
+    populationIds = c("a"), populations = c("b")
+  ),
+  "only one"
+) }})
 
 test_that("looks up population by name; unambiguous match", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -210,8 +219,10 @@ test_that("looks up population by name; unambiguous match", {
       setServer("https://my.server.com")
       # Specify fake stat so the call dies after the lookup
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c("fake"), compensationId = 0,
-          fcsFileIds = c("fid1"), populations = c("pname1")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c("fake"), compensationId = 0,
+          fcsFileIds = c("fid1"), populations = c("pname1")
+        ),
         "not allowed"
       )
     }
@@ -222,9 +233,9 @@ test_that("looks up populations by name; errors with ambiguous results", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -244,8 +255,10 @@ test_that("looks up populations by name; errors with ambiguous results", {
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c(), compensationId = 0,
-          fcsFileIds = c("fid1"), populations = c("pname1")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c(), compensationId = 0,
+          fcsFileIds = c("fid1"), populations = c("pname1")
+        ),
         "same names"
       )
     }
@@ -256,9 +269,9 @@ test_that("looks up populations by name; errors with too few results", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%2C%22pname2%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%2C%22pname2%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -277,8 +290,10 @@ test_that("looks up populations by name; errors with too few results", {
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c(), compensationId = 0,
-          fcsFileIds = c("fid1"), populations = c("pname1", "pname2")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c(), compensationId = 0,
+          fcsFileIds = c("fid1"), populations = c("pname1", "pname2")
+        ),
         "1 population\\(s\\) were not found"
       )
     }
@@ -289,12 +304,12 @@ test_that("looks up populations by name; errors with zero results", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%2C%22pname2%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%2C%22pname2%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[]',
+            content = "[]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -308,8 +323,10 @@ test_that("looks up populations by name; errors with zero results", {
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c(), compensationId = 0,
-          fcsFileIds = c("fid1"), populations = c("pname1", "pname2")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c(), compensationId = 0,
+          fcsFileIds = c("fid1"), populations = c("pname1", "pname2")
+        ),
         "2 population\\(s\\) were not found"
       )
     }
@@ -320,9 +337,9 @@ test_that("looks up populations by name; errors with too few and ambiguous resul
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%2C%22pname2%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%2C%22pname2%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -342,27 +359,25 @@ test_that("looks up populations by name; errors with too few and ambiguous resul
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c(), compensationId = 0,
-          fcsFileIds = c("fid1"), populations = c("pname1", "pname2")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c(), compensationId = 0,
+          fcsFileIds = c("fid1"), populations = c("pname1", "pname2")
+        ),
         "1 population\\(s\\) were not found"
       )
     }
   )
 })
 
-test_that("whitelists statistics", {
-  {
-    expect_error(
-      getStatistics("eid",
-        statistics = c("MEAN", "median", "quantile", "stdDev", "CV", "MAD", "eventcount", "percent", "fake1", "fake2"),
-        compensationId = 0,
-        fcsFileIds = c("fid1", "fid2"),
-        populationIds = c("p1", "p2")
-      ),
-      "Statistics \\[fake1, fake2\\] are not allowed"
-    )
-  }
-})
+test_that("whitelists statistics", {{ expect_error(
+  getStatistics("eid",
+    statistics = c("MEAN", "median", "quantile", "stdDev", "CV", "MAD", "eventcount", "percent", "fake1", "fake2"),
+    compensationId = 0,
+    fcsFileIds = c("fid1", "fid2"),
+    populationIds = c("p1", "p2")
+  ),
+  "Statistics \\[fake1, fake2\\] are not allowed"
+) }})
 
 test_that("looks up default scaleset; single match", {
   with_mock(
@@ -370,7 +385,7 @@ test_that("looks up default scaleset; single match", {
       switch(req$url,
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/scalesets?fields=%2B_id" = {
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -390,8 +405,10 @@ test_that("looks up default scaleset; single match", {
       setServer("https://my.server.com")
       # Specify bad percentOf arg so fn stops after lookup
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-          fcsFileIds = c("fid1"), populationIds = c("pname1"), percentOf = c("a", "b")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c("percent"), compensationId = 0,
+          fcsFileIds = c("fid1"), populationIds = c("pname1"), percentOf = c("a", "b")
+        ),
         "same length"
       )
     }
@@ -404,10 +421,10 @@ test_that("looks up default scaleset; no matches", {
       switch(req$url,
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/scalesets?fields=%2B_id" = {
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[]',
+            content = "[]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -421,8 +438,10 @@ test_that("looks up default scaleset; no matches", {
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-          fcsFileIds = c("fid1"), populationIds = c("pname1")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c("percent"), compensationId = 0,
+          fcsFileIds = c("fid1"), populationIds = c("pname1")
+        ),
         "No scalesets"
       )
     }
@@ -435,7 +454,7 @@ test_that("looks up default scaleset; more than one match", {
       switch(req$url,
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/scalesets?fields=%2B_id" = {
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -455,24 +474,24 @@ test_that("looks up default scaleset; more than one match", {
     {
       setServer("https://my.server.com")
       expect_error(
-        getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-          fcsFileIds = c("fid1"), populationIds = c("pname1")),
+        getStatistics("591a3b441d725115208a6fda",
+          statistics = c("percent"), compensationId = 0,
+          fcsFileIds = c("fid1"), populationIds = c("pname1")
+        ),
         "More than one scaleset"
       )
     }
   )
 })
 
-test_that("validates percentOf array is same length as populationIds", {
-  {
-    setServer("https://my.server.com")
-    expect_error(
-      getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-        fcsFileIds = c("fid1"), populationIds = c("pname1"), scaleSetId = "abc", percentOf = c("a", "b")),
-      "same length"
-    )
-  }
-})
+test_that("validates percentOf array is same length as populationIds", {{ setServer("https://my.server.com")
+  expect_error(
+    getStatistics("591a3b441d725115208a6fda",
+      statistics = c("percent"), compensationId = 0,
+      fcsFileIds = c("fid1"), populationIds = c("pname1"), scaleSetId = "abc", percentOf = c("a", "b")
+    ),
+    "same length"
+  ) }})
 
 test_that("works, percentOf specified as single value", {
   with_mock(
@@ -480,13 +499,17 @@ test_that("works, percentOf specified as single value", {
       switch(req$url,
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/bulkstatistics" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
-          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":\"591a3b441d725115208a6fde\"}')
-          response = httptest::fake_response(
+          body <- rawToChar(req$options$postfields)
+          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":\"591a3b441d725115208a6fde\"}') # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
-              {"fcsFileId":"591a3b441d725115208a6fdb","filename":"abc.fcs","populationId":"591a3b441d725115208a6fdc","population":"positivePop","annotations":{"row":"A","column":"1"},"parentPopulation":"singlets","parentPopulationId":"591a3b441d725115208a6fde","percent":21.89535144846171}
+              {
+                "fcsFileId":"591a3b441d725115208a6fdb","filename":"abc.fcs","populationId":"591a3b441d725115208a6fdc",
+                "population":"positivePop","annotations":{"row":"A","column":"1"},"parentPopulation":"singlets",
+                "parentPopulationId":"591a3b441d725115208a6fde","percent":21.89535144846171
+              }
             ]',
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
@@ -500,9 +523,11 @@ test_that("works, percentOf specified as single value", {
     },
     {
       setServer("https://my.server.com")
-      res = getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
+      res <- getStatistics("591a3b441d725115208a6fda",
+        statistics = c("percent"), compensationId = 0,
         fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc"),
-        scaleSetId = "591a3b441d725115208a6fdd", percentOf = "591a3b441d725115208a6fde")
+        scaleSetId = "591a3b441d725115208a6fdd", percentOf = "591a3b441d725115208a6fde"
+      )
       expect_true(is.data.frame(res))
       expect_equal(res[1, "filename"], "abc.fcs")
       expect_equal(res[1, "annotations"]$row, "A")
@@ -516,13 +541,13 @@ test_that("works, percentOf not specified", {
       switch(req$url,
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/bulkstatistics" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
-          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true}')
-          response = httptest::fake_response(
+          body <- rawToChar(req$options$postfields)
+          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true}') # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[
-            ]',
+            content = "[
+            ]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -535,9 +560,11 @@ test_that("works, percentOf not specified", {
     },
     {
       setServer("https://my.server.com")
-      getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
+      getStatistics("591a3b441d725115208a6fda",
+        statistics = c("percent"), compensationId = 0,
         fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc"),
-        scaleSetId = "591a3b441d725115208a6fdd")
+        scaleSetId = "591a3b441d725115208a6fdd"
+      )
     }
   )
 })
@@ -548,13 +575,13 @@ test_that("works, percentOf specified as an array", {
       switch(req$url,
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/bulkstatistics" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
-          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\",\"591a3b441d725115208a6fd1\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":[\"591a3b441d725115208a6fde\",\"591a3b441d725115208a6fd2\"]}')
-          response = httptest::fake_response(
+          body <- rawToChar(req$options$postfields)
+          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\",\"591a3b441d725115208a6fd1\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":[\"591a3b441d725115208a6fde\",\"591a3b441d725115208a6fd2\"]}') # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[
-            ]',
+            content = "[
+            ]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -567,9 +594,11 @@ test_that("works, percentOf specified as an array", {
     },
     {
       setServer("https://my.server.com")
-      getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1"),
-        scaleSetId = "591a3b441d725115208a6fdd", percentOf = c("591a3b441d725115208a6fde", "591a3b441d725115208a6fd2"))
+      getStatistics("591a3b441d725115208a6fda",
+        statistics = c("percent"), compensationId = 0,
+        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1"), # nolint
+        scaleSetId = "591a3b441d725115208a6fdd", percentOf = c("591a3b441d725115208a6fde", "591a3b441d725115208a6fd2")
+      )
     }
   )
 })
@@ -578,9 +607,9 @@ test_that("works, percentOf specified as a single name", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -593,12 +622,12 @@ test_that("works, percentOf specified as a single name", {
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/bulkstatistics" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
-          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\",\"591a3b441d725115208a6fd1\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":"591a3b5f1d725115208a7088"}')
-          response = httptest::fake_response(
+          body <- rawToChar(req$options$postfields)
+          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\",\"591a3b441d725115208a6fd1\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":"591a3b5f1d725115208a7088"}') # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[]',
+            content = "[]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -611,9 +640,11 @@ test_that("works, percentOf specified as a single name", {
     },
     {
       setServer("https://my.server.com")
-      getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1"),
-        scaleSetId = "591a3b441d725115208a6fdd", percentOf = "pname1")
+      getStatistics("591a3b441d725115208a6fda",
+        statistics = c("percent"), compensationId = 0,
+        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1"), # nolint
+        scaleSetId = "591a3b441d725115208a6fdd", percentOf = "pname1"
+      )
     }
   )
 })
@@ -622,9 +653,9 @@ test_that("works, percentOf specified as an array of names", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%2C%22pname2%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%2C%22pname2%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -638,12 +669,12 @@ test_that("works, percentOf specified as an array of names", {
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/bulkstatistics" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
-          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\",\"591a3b441d725115208a6fd1\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":["591a3b5f1d725115208a7088","591a3b5f1d725115208a7090"]}')
-          response = httptest::fake_response(
+          body <- rawToChar(req$options$postfields)
+          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\",\"591a3b441d725115208a6fd1\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":["591a3b5f1d725115208a7088","591a3b5f1d725115208a7090"]}') # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[]',
+            content = "[]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -656,9 +687,12 @@ test_that("works, percentOf specified as an array of names", {
     },
     {
       setServer("https://my.server.com")
-      getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1"),
-        scaleSetId = "591a3b441d725115208a6fdd", percentOf = c("pname1", "pname2"))
+      getStatistics("591a3b441d725115208a6fda",
+        statistics = c("percent"), compensationId = 0,
+        fcsFileIds = c("591a3b441d725115208a6fdb"),
+        populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1"),
+        scaleSetId = "591a3b441d725115208a6fdd", percentOf = c("pname1", "pname2")
+      )
     }
   )
 })
@@ -667,9 +701,9 @@ test_that("works, percentOf specified as a mixed array of names, IDs and UNGATED
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       switch(req$url,
-        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%5D%29" = {
+        "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations?fields=%2Bname&query=in%28name%2C%20%5B%22pname1%22%5D%29" = { # nolint
           expect_equal(req$method, "GET")
-          response = httptest::fake_response(
+          response <- httptest::fake_response(
             req$url,
             req$method,
             content = '[
@@ -682,12 +716,12 @@ test_that("works, percentOf specified as a mixed array of names, IDs and UNGATED
         },
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/bulkstatistics" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
-          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":["591a3b441d725115208a6fdc","591a3b441d725115208a6fd1","591a3b441d725115208a6fe1"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":["591a3b5f1d725115208a7088","591a3b5f1d725115208a7090",""]}')
-          response = httptest::fake_response(
+          body <- rawToChar(req$options$postfields)
+          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":["591a3b441d725115208a6fdc","591a3b441d725115208a6fd1","591a3b441d725115208a6fe1"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":["591a3b5f1d725115208a7088","591a3b5f1d725115208a7090",""]}') # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[]',
+            content = "[]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -700,9 +734,11 @@ test_that("works, percentOf specified as a mixed array of names, IDs and UNGATED
     },
     {
       setServer("https://my.server.com")
-      getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1", "591a3b441d725115208a6fe1"),
-        scaleSetId = "591a3b441d725115208a6fdd", percentOf = c("pname1", "591a3b5f1d725115208a7090", UNGATED))
+      getStatistics("591a3b441d725115208a6fda",
+        statistics = c("percent"), compensationId = 0,
+        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1", "591a3b441d725115208a6fe1"), # nolint
+        scaleSetId = "591a3b441d725115208a6fdd", percentOf = c("pname1", "591a3b5f1d725115208a7090", UNGATED)
+      )
     }
   )
 })
@@ -713,12 +749,12 @@ test_that("works, percentOf specified as null (ungated)", {
       switch(req$url,
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/bulkstatistics" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
-          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\",\"591a3b441d725115208a6fd1\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":""}')
-          response = httptest::fake_response(
+          body <- rawToChar(req$options$postfields)
+          expect_equal(body, '{\"fcsFileIds\":[\"591a3b441d725115208a6fdb\"],\"statistics\":[\"percent\"],\"populationIds\":[\"591a3b441d725115208a6fdc\",\"591a3b441d725115208a6fd1\"],\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":""}') # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[]',
+            content = "[]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -731,9 +767,11 @@ test_that("works, percentOf specified as null (ungated)", {
     },
     {
       setServer("https://my.server.com")
-      getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1"),
-        scaleSetId = "591a3b441d725115208a6fdd", percentOf = UNGATED)
+      getStatistics("591a3b441d725115208a6fda",
+        statistics = c("percent"), compensationId = 0,
+        fcsFileIds = c("591a3b441d725115208a6fdb"), populationIds = c("591a3b441d725115208a6fdc", "591a3b441d725115208a6fd1"), # nolint
+        scaleSetId = "591a3b441d725115208a6fdd", percentOf = UNGATED
+      )
     }
   )
 })
@@ -744,12 +782,12 @@ test_that("works, gets statistics for all FCS files and populations", {
       switch(req$url,
         "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/bulkstatistics" = {
           expect_equal(req$method, "POST")
-          body = rawToChar(req$options$postfields)
-          expect_equal(body, '{\"fcsFileIds\":null,\"statistics\":[\"percent\"],\"populationIds\":null,\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":""}')
-          response = httptest::fake_response(
+          body <- rawToChar(req$options$postfields)
+          expect_equal(body, '{\"fcsFileIds\":null,\"statistics\":[\"percent\"],\"populationIds\":null,\"compensationId\":0,\"q\":0.5,\"scaleSetId\":\"591a3b441d725115208a6fdd\",\"format\":\"json\",\"annotations\":true,\"percentOf\":""}') # nolint
+          response <- httptest::fake_response(
             req$url,
             req$method,
-            content = '[]',
+            content = "[]",
             status_code = 200,
             headers = list(`Content-Type` = "application/json")
           )
@@ -762,9 +800,11 @@ test_that("works, gets statistics for all FCS files and populations", {
     },
     {
       setServer("https://my.server.com")
-      getStatistics("591a3b441d725115208a6fda", statistics = c("percent"), compensationId = 0,
-                    fcsFileIds = NULL, populationIds = NULL,
-                    scaleSetId = "591a3b441d725115208a6fdd", percentOf = UNGATED)
+      getStatistics("591a3b441d725115208a6fda",
+        statistics = c("percent"), compensationId = 0,
+        fcsFileIds = NULL, populationIds = NULL,
+        scaleSetId = "591a3b441d725115208a6fdd", percentOf = UNGATED
+      )
     }
   )
 })

--- a/tests/testthat/test-setFcsFilePanel.R
+++ b/tests/testthat/test-setFcsFilePanel.R
@@ -4,13 +4,13 @@ test_that("Correct HTTP request is made", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "PATCH")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc")
-      body = rawToChar(req$options$postfields)
-      expect_equal(body, '{"panelName":"Panel 1","panel":[{"index":1,"channel":"FSC-A"},{"index":7,"channel":"Blue530-A","reagent":"CD3"}]}')
-      response = httptest::fake_response(
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/fcsfiles/591a3b441d725115208a6fdc") # nolint
+      body <- rawToChar(req$options$postfields)
+      expect_equal(body, '{"panelName":"Panel 1","panel":[{"index":1,"channel":"FSC-A"},{"index":7,"channel":"Blue530-A","reagent":"CD3"}]}') # nolint
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"filename":"Specimen_001_A2_A02_MeOHperm(DL350neg).fcs","gridId":"593f3ae211005114b1bf03e2","hasFileInternalComp":true,"panelName":"Panel 1","__v":0,"_id":"591a3b441d725115208a6fdc","spillString":"8,Blue530-A,Vio450-A,Vio605-A,UV450-A,Red670-A,YG582-A,YG610-A,YG780-A,1,0,0,0,0,0,0,0,0,1,0.019999998552000027,0.055000000000000014,0,0,0,0,0.003000000000000001,0.012999999058800013,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1","crc32c":"76633d32","eventCount":164684,"md5":"4a0ded33c1f55c6ff52c90dbe3c4894d","experimentId":"591a3b441d725115208a6fda","panel":[{"index":1,"channel":"FSC-A"},{"index":7,"reagent":"CD3","channel":"Blue530-A"}],"annotations":[{"type":"any","value":"myvalue","name":"annotation 1"},{"type":"any","value":"2.12","name":"annotation 2"}]}',
+        content = '{"filename":"Specimen_001_A2_A02_MeOHperm(DL350neg).fcs","gridId":"593f3ae211005114b1bf03e2","hasFileInternalComp":true,"panelName":"Panel 1","__v":0,"_id":"591a3b441d725115208a6fdc","spillString":"8,Blue530-A,Vio450-A,Vio605-A,UV450-A,Red670-A,YG582-A,YG610-A,YG780-A,1,0,0,0,0,0,0,0,0,1,0.019999998552000027,0.055000000000000014,0,0,0,0,0.003000000000000001,0.012999999058800013,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1","crc32c":"76633d32","eventCount":164684,"md5":"4a0ded33c1f55c6ff52c90dbe3c4894d","experimentId":"591a3b441d725115208a6fda","panel":[{"index":1,"channel":"FSC-A"},{"index":7,"reagent":"CD3","channel":"Blue530-A"}],"annotations":[{"type":"any","value":"myvalue","name":"annotation 1"},{"type":"any","value":"2.12","name":"annotation 2"}]}', # nolint
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -18,11 +18,11 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      panel = list(
+      panel <- list(
         list("index" = 1, "channel" = "FSC-A"),
         list("index" = 7, "channel" = "Blue530-A", "reagent" = "CD3")
       )
-      resp = setFcsFilePanel("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc", "Panel 1", panel)
+      resp <- setFcsFilePanel("591a3b441d725115208a6fda", "591a3b441d725115208a6fdc", "Panel 1", panel)
     }
   )
 })

--- a/tests/testthat/test-setServer.R
+++ b/tests/testthat/test-setServer.R
@@ -11,5 +11,5 @@ test_that("Tolerates trailing /", {
 })
 
 test_that("Requires https", {
-  expect_error((function () setServer("http://my.server.com/"))())
+  expect_error((function() setServer("http://my.server.com/"))())
 })

--- a/tests/testthat/test-updateExperiment.R
+++ b/tests/testthat/test-updateExperiment.R
@@ -5,13 +5,13 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "PATCH")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda")
-      body = rawToChar(req$options$postfields)
+      body <- rawToChar(req$options$postfields)
       expect_equal(body, '{"name":"new name"}')
 
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"name":"new name","created":"2017-06-10T01:00:23.638Z","__v":0,"_id":"593b44a7ff5925084dd96ed1","public":false,"uploader":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"permissions":{},"primaryResearcher":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"updated":"2017-06-10T01:00:25.632Z"}',
+        content = '{"name":"new name","created":"2017-06-10T01:00:23.638Z","__v":0,"_id":"593b44a7ff5925084dd96ed1","public":false,"uploader":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"permissions":{},"primaryResearcher":{"_id":"57e497d9e3f1430e16805d17","lastName":"Bjornson","id":"57e497d9e3f1430e16805d17","email":"zbjornson@primitybio.com","username":"zbjornson","firstName":"Zach","fullName":"Zach Bjornson"},"updated":"2017-06-10T01:00:25.632Z"}', # nolint
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -19,7 +19,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = updateExperiment("591a3b441d725115208a6fda", list("name" = "new name"))
+      resp <- updateExperiment("591a3b441d725115208a6fda", list("name" = "new name"))
       expect_equal(resp$name, "new name")
     }
   )

--- a/tests/testthat/test-updateGate.R
+++ b/tests/testthat/test-updateGate.R
@@ -4,15 +4,14 @@ test_that("Correct HTTP request is made", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "PATCH")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates/592640aa298f1480900e10e4")
-      body = rawToChar(req$options$postfields)
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates/592640aa298f1480900e10e4") # nolint
+      body <- rawToChar(req$options$postfields)
       expect_equal(body, '{"name":"new name"}')
 
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"rectangle":{"y2":214399.74226804124,"x2":182870.51546391752,"y1":190978.03092783503,"x1":118010.39175257733},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RectangleGate","name":"new name","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}',
-
+        content = '{"__v":0,"experimentId":"591a3b441d725115208a6fda","model":{"label":[150440.453608247,202688.886597938],"rectangle":{"y2":214399.74226804124,"x2":182870.51546391752,"y1":190978.03092783503,"x1":118010.39175257733},"locked":false},"gid":"592640a5a6a1d6256ec9b08a","xChannel":"FSC-A","type":"RectangleGate","name":"new name","parentPopulationId":null,"yChannel":"FSC-W","_id":"592640aa298f1480900e10e4","tailoredPerFile":false,"id":"592640aa298f1480900e10e4"}', # nolint
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,7 +19,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = updateGate("591a3b441d725115208a6fda", "592640aa298f1480900e10e4", list("name" = "new name"))
+      resp <- updateGate("591a3b441d725115208a6fda", "592640aa298f1480900e10e4", list("name" = "new name"))
       expect_equal(resp$name, "new name")
     }
   )

--- a/tests/testthat/test-updateGateFamily.R
+++ b/tests/testthat/test-updateGateFamily.R
@@ -4,15 +4,14 @@ test_that("Correct HTTP request is made", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "PATCH")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates?gid=592640aa298f1480900e10e4")
-      body = rawToChar(req$options$postfields)
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/gates?gid=592640aa298f1480900e10e4") # nolint
+      body <- rawToChar(req$options$postfields)
       expect_equal(body, '{"name":"new name"}')
 
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"nModified": 1}',
-
+        content = '{"nModified": 1}',
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,7 +19,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = updateGateFamily("591a3b441d725115208a6fda", "592640aa298f1480900e10e4", list("name" = "new name"))
+      resp <- updateGateFamily("591a3b441d725115208a6fda", "592640aa298f1480900e10e4", list("name" = "new name"))
       expect_equal(resp$nModified, 1)
     }
   )

--- a/tests/testthat/test-updatePopulation.R
+++ b/tests/testthat/test-updatePopulation.R
@@ -4,15 +4,14 @@ test_that("Correct HTTP request is made", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "PATCH")
-      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations/592640aa298f1480900e10e4")
-      body = rawToChar(req$options$postfields)
+      expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fda/populations/592640aa298f1480900e10e4") # nolint
+      body <- rawToChar(req$options$postfields)
       expect_equal(body, '{"name":"new name"}')
 
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"experimentId":"591a3b441d725115208a6fda","name":"new name","parentId":null,"gates":"{\\\"$and\\\":[\\\"591a3b441d725115203a6fda\\\"]}","terminalGateGid":"591a3b441d725115203a6fda"}',
-
+        content = '{"experimentId":"591a3b441d725115208a6fda","name":"new name","parentId":null,"gates":"{\\\"$and\\\":[\\\"591a3b441d725115203a6fda\\\"]}","terminalGateGid":"591a3b441d725115203a6fda"}', # nolint
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -20,7 +19,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = updatePopulation("591a3b441d725115208a6fda", "592640aa298f1480900e10e4", list("name" = "new name"))
+      resp <- updatePopulation("591a3b441d725115208a6fda", "592640aa298f1480900e10e4", list("name" = "new name"))
       expect_equal(resp$name, "new name")
     }
   )

--- a/tests/testthat/test-uploadAttachment.R
+++ b/tests/testthat/test-uploadAttachment.R
@@ -5,10 +5,10 @@ test_that("Correct HTTP request is made", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fdb/attachments")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content = '{"_id":"591a3b441d725115208a6fda","filename":"test.txt","experimentId":"591a3b441d725115208a6fdb","crc32c":"4d9f30b7","md5":"b6cb0f190337db50a672e9f3dc616e10","size":9}',
+        content = '{"_id":"591a3b441d725115208a6fda","filename":"test.txt","experimentId":"591a3b441d725115208a6fdb","crc32c":"4d9f30b7","md5":"b6cb0f190337db50a672e9f3dc616e10","size":9}', # nolint
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -16,7 +16,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = uploadAttachment("591a3b441d725115208a6fdb", "../test.txt")
+      resp <- uploadAttachment("591a3b441d725115208a6fdb", "../test.txt")
       expect_equal(resp$`_id`, "591a3b441d725115208a6fda")
       expect_equal(resp$filename, "test.txt")
     }

--- a/tests/testthat/test-uploadFcsFile.R
+++ b/tests/testthat/test-uploadFcsFile.R
@@ -6,10 +6,10 @@ test_that("Correct HTTP request is made", {
       expect_equal(req$method, "POST")
       expect_equal(req$url, "https://my.server.com/api/v1/experiments/591a3b441d725115208a6fdb/fcsfiles")
       # Not sure the best way to assert on this.
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='{"__v":0,"_id":"591a3b441d725115208a6fda","filename":"5k.fcs"}',
+        content = '{"__v":0,"_id":"591a3b441d725115208a6fda","filename":"5k.fcs"}',
         status_code = 201,
         headers = list(`Content-Type` = "application/json")
       )
@@ -17,7 +17,7 @@ test_that("Correct HTTP request is made", {
     },
     {
       setServer("https://my.server.com")
-      resp = uploadFcsFile("591a3b441d725115208a6fdb", "../5k.fcs")
+      resp <- uploadFcsFile("591a3b441d725115208a6fdb", "../5k.fcs")
       expect_equal(resp$`_id`, "591a3b441d725115208a6fda")
       expect_equal(resp$filename, "5k.fcs")
     }

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -2,43 +2,27 @@ context("utils")
 
 # test_that("Sets the UA correctly", {})
 
-test_that("baseGet requires baseURL to have been set", {
-  {
-    pkg.env$baseURL = ""
-    expect_error(baseGet(), "setServer")
-  }
-})
+test_that("baseGet requires baseURL to have been set", {{ pkg.env$baseURL <- ""
+  expect_error(baseGet(), "setServer") }})
 
-test_that("basePut requires baseURL to have been set", {
-  {
-    pkg.env$baseURL = ""
-    expect_error(basePut(), "setServer")
-  }
-})
+test_that("basePut requires baseURL to have been set", {{ pkg.env$baseURL <- ""
+  expect_error(basePut(), "setServer") }})
 
-test_that("basePost requires baseURL to have been set", {
-  {
-    pkg.env$baseURL = ""
-    expect_error(basePost(), "setServer")
-  }
-})
+test_that("basePost requires baseURL to have been set", {{ pkg.env$baseURL <- ""
+  expect_error(basePost(), "setServer") }})
 
-test_that("baseDelete requires baseURL to have been set", {
-  {
-    pkg.env$baseURL = ""
-    expect_error(baseDelete(), "setServer")
-  }
-})
+test_that("baseDelete requires baseURL to have been set", {{ pkg.env$baseURL <- ""
+  expect_error(baseDelete(), "setServer") }})
 
 test_that("lookupByName stops for 0 matches", {
   with_mock(
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "GET")
       expect_match(req$url, "https://cellengine.com/api/v1/experiments")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='[]',
+        content = "[]",
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -46,8 +30,10 @@ test_that("lookupByName stops for 0 matches", {
     },
     {
       setServer("https://cellengine.com")
-      expect_error(lookupByName("experiments", byName("My experiment")),
-                   "Resource with the name 'My experiment' does not exist.")
+      expect_error(
+        lookupByName("experiments", byName("My experiment")),
+        "Resource with the name 'My experiment' does not exist."
+      )
     }
   )
 })
@@ -57,10 +43,10 @@ test_that("lookupByName stops for >1 match", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "GET")
       expect_match(req$url, "https://cellengine.com/api/v1/experiments")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='[{"name": "My experiment", "_id": "591a3b441d725115208a6fda"}, {"name": "My experiment", "_id": "591a3b441d725115208a6fdb"}]',
+        content = '[{"name": "My experiment", "_id": "591a3b441d725115208a6fda"}, {"name": "My experiment", "_id": "591a3b441d725115208a6fdb"}]', # nolint
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -68,8 +54,10 @@ test_that("lookupByName stops for >1 match", {
     },
     {
       setServer("https://cellengine.com")
-      expect_error(lookupByName("experiments", byName("My experiment")),
-                   "More than one resource with the name 'My experiment' exists.")
+      expect_error(
+        lookupByName("experiments", byName("My experiment")),
+        "More than one resource with the name 'My experiment' exists."
+      )
     }
   )
 })
@@ -79,10 +67,10 @@ test_that("lookupByName returns for 1 match", {
     `httr::request_perform` = function(req, handle, refresh) {
       expect_equal(req$method, "GET")
       expect_match(req$url, "https://cellengine.com/api/v1/experiments")
-      response = httptest::fake_response(
+      response <- httptest::fake_response(
         req$url,
         req$method,
-        content='[{"name": "My experiment", "_id": "591a3b441d725115208a6fda"}]',
+        content = '[{"name": "My experiment", "_id": "591a3b441d725115208a6fda"}]',
         status_code = 200,
         headers = list(`Content-Type` = "application/json")
       )
@@ -90,8 +78,10 @@ test_that("lookupByName returns for 1 match", {
     },
     {
       setServer("https://cellengine.com")
-      expect_equal(lookupByName("experiments", byName("My experiment")),
-                   "591a3b441d725115208a6fda")
+      expect_equal(
+        lookupByName("experiments", byName("My experiment")),
+        "591a3b441d725115208a6fda"
+      )
     }
   )
 })


### PR DESCRIPTION
- Add .lintr config
- Format and lint all files
- clamp_q -> clampQ
- Reduce cyclomatic complexity of getEvents
- Reduce cyclomatic complexity of getStatistics
- Add linting workflow

This was formatted with the `styler`/`tidyverse` defaults (https://styler.r-lib.org/index.html).

Q's:

- [x] Do we like this formatting style?
- [x] Should I add a [pre-commit hook](https://github.com/lorenzwalthert/precommit) for `styler`? Currently the use of `styler` is not enforced anywhere.