### PR TITLE
spec(docs): provide example for appending annotations

### DIFF
--- a/R/annotateFcsFile.R
+++ b/R/annotateFcsFile.R
@@ -8,7 +8,7 @@
 #'
 #' Note: if you retrieve FCS files in bulk, such as with \code{getFcsFiles},
 #' \code{file$annotations} will return a nested list. Be sure to extract the
-#' annotations from this list before appending new ones.
+#' annotations from this list before appending new ones (see examples below).
 #'
 #' @param experimentId ID of experiment.
 #' @param fcsFileId ID of FCS file.
@@ -19,6 +19,13 @@
 #' annotations <- list(list(name = "annotations 1", value = 1),
 #'   list(name = "annotation 2", value = "myValue"))
 #' annotateFcsFile(experimentId, fcsFileId, annotations)
+#'
+#' # or, to append annotations
+#' files = getFcsFiles(id)
+#' file = files[1,]
+#' annos = file$annotations[[1]]
+#' annos[nrow(annos)+1,] <- list("abc", "def")
+#' annotateFcsFile(experimentId, file`_id`, annos)
 #' }
 annotateFcsFile <- function(experimentId, fcsFileId, annotations) {
   checkDefined(experimentId)

--- a/man/annotateFcsFile.Rd
+++ b/man/annotateFcsFile.Rd
@@ -23,12 +23,19 @@ the existing annotations. Append new annotations with \code{rbind}.
 
 Note: if you retrieve FCS files in bulk, such as with \code{getFcsFiles},
 \code{file$annotations} will return a nested list. Be sure to extract the
-annotations from this list before appending new ones.
+annotations from this list before appending new ones (see examples below).
 }
 \examples{
 \dontrun{
 annotations <- list(list(name = "annotations 1", value = 1),
   list(name = "annotation 2", value = "myValue"))
 annotateFcsFile(experimentId, fcsFileId, annotations)
+
+# or, to append annotations
+files = getFcsFiles(id)
+file = files[1,]
+annos = file$annotations[[1]]
+annos[nrow(annos)+1,] <- list("abc", "def")
+annotateFcsFile(experimentId, file`_id`, annos)
 }
 }

--- a/man/applyScaleSet.Rd
+++ b/man/applyScaleSet.Rd
@@ -19,10 +19,10 @@ Applies a ScaleSet to a dataframe of events
 }
 \examples{
 \dontrun{
-getEvents(experimentId, fcsFileId, destination = 'myFile.fcs')
-events = flowCore::read.FCS('myFile.fcs')
-data = events@exprs
-scaleSet = getScaleSets(experimentId)[1,]
+getEvents(experimentId, fcsFileId, destination = "myFile.fcs")
+events <- flowCore::read.FCS("myFile.fcs")
+data <- events@exprs
+scaleSet <- getScaleSets(experimentId)[1, ]
 applyScaleSet(scaleSet, data)
 }
 }


### PR DESCRIPTION
This is a temporary fix for #44, and doesn't really close it